### PR TITLE
Add automated Index managment for tables

### DIFF
--- a/audit.congress.schema.json
+++ b/audit.congress.schema.json
@@ -1,6 +1,6 @@
 {
     "name": "Audit Congress Schema",
-    "version": ".2",
+    "version": ".3",
     "tables": 
         [
 
@@ -119,6 +119,54 @@
                     "fax": { "type": "VARCHAR(25)", "null": "YES" }
                 }
             },
+            {
+                "name": "Committees",
+                "columns": {
+                    "thomasId": { "type": "VARCHAR(50)", "null": "NO", "primary": true },
+                    "parentId": { "type": "VARCHAR(50)", "null": "YES" },
+
+                    "type": { "type": "VARCHAR(50)", "null": "NO" },
+                    "name": { "type": "VARCHAR(250)", "null": "NO" },
+
+                    "wikipedia": { "type": "VARCHAR(250)", "null": "YES" },
+                    
+                    "jurisdiction": { "type": "VARCHAR(250)", "null": "YES" },
+                    "jurisdiction_source": { "type": "VARCHAR(250)", "null": "YES" },
+
+                    "url": { "type": "VARCHAR(250)", "null": "YES" },
+                    "rss_url": { "type": "VARCHAR(250)", "null": "YES" },
+                    "minority_url": { "type": "VARCHAR(250)", "null": "YES" },
+                    "minority_rss_url": { "type": "VARCHAR(250)", "null": "YES" },
+                    "youtubeId": { "type": "VARCHAR(250)", "null": "YES" },
+
+                    "address": { "type": "VARCHAR(100)", "null": "YES" },
+                    "phone": { "type": "VARCHAR(25)", "null": "YES" },
+                    
+                    "isCurrent": { "type": "TINYINT(1)", "null": "NO" }
+                }
+            },
+            {
+                "name": "CommitteeHistory",
+                "columns": {
+                    "thomasId": { "type": "VARCHAR(50)", "null": "NO"},
+                    "parentId": { "type": "VARCHAR(50)", "null": "YES" },
+                    "type": { "type": "VARCHAR(50)", "null": "NO" },
+
+                    "congress": { "type": "INT", "null": "NO" },
+                    "name": { "type": "VARCHAR(250)", "null": "NO" }
+                }
+            },
+            {
+                "name": "CommitteeMembership",
+                "columns": {
+                    "thomasId": { "type": "VARCHAR(50)", "null": "NO" },
+                    "bioguideId": { "type": "VARCHAR(50)", "null": "NO"},
+
+                    "party": { "type": "VARCHAR(50)", "null": "NO" },
+                    "title": { "type": "VARCHAR(50)", "null": "YES" },
+                    "memberRank": { "type": "INT", "null": "NO" }
+                }
+            },
 
 
 
@@ -213,62 +261,6 @@
                     "isOriginal": { "type": "TINYINT(1)", "null": "NO" }
                 }
             },
-
-
-
-            {
-                "name": "Committees",
-                "columns": {
-                    "thomasId": { "type": "VARCHAR(50)", "null": "NO", "primary": true },
-                    "parentId": { "type": "VARCHAR(50)", "null": "YES" },
-
-                    "type": { "type": "VARCHAR(50)", "null": "NO" },
-                    "name": { "type": "VARCHAR(250)", "null": "NO" },
-
-                    "wikipedia": { "type": "VARCHAR(250)", "null": "YES" },
-                    
-                    "jurisdiction": { "type": "VARCHAR(250)", "null": "YES" },
-                    "jurisdiction_source": { "type": "VARCHAR(250)", "null": "YES" },
-
-                    "url": { "type": "VARCHAR(250)", "null": "YES" },
-                    "rss_url": { "type": "VARCHAR(250)", "null": "YES" },
-                    "minority_url": { "type": "VARCHAR(250)", "null": "YES" },
-                    "minority_rss_url": { "type": "VARCHAR(250)", "null": "YES" },
-                    "youtubeId": { "type": "VARCHAR(250)", "null": "YES" },
-
-                    "address": { "type": "VARCHAR(100)", "null": "YES" },
-                    "phone": { "type": "VARCHAR(25)", "null": "YES" },
-                    
-                    "isCurrent": { "type": "TINYINT(1)", "null": "NO" }
-                }
-            },
-            {
-                "name": "CommitteeHistory",
-                "columns": {
-                    "thomasId": { "type": "VARCHAR(50)", "null": "NO"},
-                    "parentId": { "type": "VARCHAR(50)", "null": "YES" },
-                    "type": { "type": "VARCHAR(50)", "null": "NO" },
-
-                    "congress": { "type": "INT", "null": "NO" },
-                    "name": { "type": "VARCHAR(250)", "null": "NO" }
-                }
-            },
-            {
-                "name": "CommitteeMembership",
-                "columns": {
-                    "thomasId": { "type": "VARCHAR(50)", "null": "NO" },
-                    "bioguideId": { "type": "VARCHAR(50)", "null": "NO"},
-
-                    "party": { "type": "VARCHAR(50)", "null": "NO" },
-                    "title": { "type": "VARCHAR(50)", "null": "YES" },
-                    "memberRank": { "type": "INT", "null": "NO" }
-                }
-            },
-
-
-
-
-
             {
                 "name": "BillActions",
                 "columns": {

--- a/audit.congress.schema.json
+++ b/audit.congress.schema.json
@@ -53,6 +53,10 @@
                     "imageUrl": { "type": "VARCHAR(250)", "null": "YES" },
                     "imageAttribution": { "type": "VARCHAR(500)", "null": "YES" },
                     "isCurrent": { "type": "TINYINT(1)", "null": "NO" }
+                },
+                "indexes": {
+                    "gender_index": ["gender"],
+                    "isCurrent_index": ["isCurrent"]
                 }
             },
             {
@@ -251,6 +255,10 @@
                     "titleAs": { "type": "VARCHAR(250)", "null": "YES" },
                     "titleType": { "type": "VARCHAR(250)", "null": "YES" },
                     "isForPortion": { "type": "VARCHAR(250)", "null": "YES" }
+                },
+                "indexes": {
+                    "congress_type_index": ["congress", "type"],
+                    "type_index": ["type"]
                 }
             },            
             {
@@ -267,6 +275,11 @@
                     "withdrawnAt": { "type": "DATE", "null": "NO" },
 
                     "isOriginal": { "type": "TINYINT(1)", "null": "NO" }
+                },
+                "indexes": {
+                    "congress_type_index": ["congress", "type"],
+                    "type_index": ["type"],
+                    "bioguideid_index": ["bioguideId"]
                 }
             },
             {
@@ -285,6 +298,10 @@
                     "how": { "type": "VARCHAR(250)", "null": "YES" },
 
                     "acted": { "type": "DATE", "null": "NO" }
+                },
+                "indexes": {
+                    "congress_type_index": ["congress", "type"],
+                    "type_index": ["type"]
                 }
             },
             {

--- a/audit.congress.schema.json
+++ b/audit.congress.schema.json
@@ -214,8 +214,8 @@
                     "updated": { "type": "VARCHAR(50)", "null": "NO" }
                 },
                 "indexes": {
-                    "congress_type": ["congress", "type"],
-                    "type": ["type"]
+                    "congress_type_index": ["congress", "type"],
+                    "type_index": ["type"]
                 }
             },
             {
@@ -230,6 +230,10 @@
                     "subjectIndex": { "type": "INT", "null": "NO" },
 
                     "subject": { "type": "VARCHAR(250)", "null": "NO" }
+                },
+                "indexes": {
+                    "congress_type_index": ["congress", "type"],
+                    "type_index": ["type"]
                 }
             },
             {

--- a/audit.congress.schema.json
+++ b/audit.congress.schema.json
@@ -212,6 +212,10 @@
                     
                     "introduced": { "type": "VARCHAR(50)", "null": "NO" },
                     "updated": { "type": "VARCHAR(50)", "null": "NO" }
+                },
+                "indexes": {
+                    "congress_type": ["congress", "type"],
+                    "type": ["type"]
                 }
             },
             {

--- a/src/php/mysql.connector/autoload.php
+++ b/src/php/mysql.connector/autoload.php
@@ -15,6 +15,7 @@ require_once MYSQLCONNECTOR_FOLDER."\\structures\mysql.row.php";
 require_once MYSQLCONNECTOR_FOLDER."\\structures\mysql.schema.enforcer.php";
 require_once MYSQLCONNECTOR_FOLDER."\\structures\mysql.database.php";
 require_once MYSQLCONNECTOR_FOLDER."\\structures\mysql.table.php";
+require_once MYSQLCONNECTOR_FOLDER."\\structures\mysql.compareable.set.php";
 require_once MYSQLCONNECTOR_FOLDER."\\structures\mysql.columns.php";
 require_once MYSQLCONNECTOR_FOLDER."\\structures\mysql.indexes.php";
 

--- a/src/php/mysql.connector/autoload.php
+++ b/src/php/mysql.connector/autoload.php
@@ -16,6 +16,7 @@ require_once MYSQLCONNECTOR_FOLDER."\\structures\mysql.schema.enforcer.php";
 require_once MYSQLCONNECTOR_FOLDER."\\structures\mysql.database.php";
 require_once MYSQLCONNECTOR_FOLDER."\\structures\mysql.table.php";
 require_once MYSQLCONNECTOR_FOLDER."\\structures\mysql.columns.php";
+require_once MYSQLCONNECTOR_FOLDER."\\structures\mysql.indexes.php";
 
 require_once MYSQLCONNECTOR_FOLDER."\\abstract.sql.object.php";
 

--- a/src/php/mysql.connector/structures/mysql.columns.php
+++ b/src/php/mysql.connector/structures/mysql.columns.php
@@ -11,10 +11,6 @@ namespace MySqlConnector {
             }
         }
 
-        //Return the names for each column
-        public function names() {
-            return array_keys($this->columns);
-        }
         //Return the name=>type for each column
         public function namesAndTypes() {
             $namesAndTypes = array();
@@ -29,25 +25,6 @@ namespace MySqlConnector {
                 if ($thisColumn->isPrimary) array_push($createStrings, $thisColumn->getPrimaryKeyString());
             }
             return $createStrings;
-        }
-
-
-        //Return all the columns as an array
-        public function getColumns() {
-            $array_columns = array();
-            foreach ($this->columns as $name=>$column) array_push($array_columns, $column); 
-            return $array_columns;
-        }
-        //Return the column given by $name
-        public function getColumn($name) { 
-            if (isset($this->columns[$name])) return $this->columns[$name]; 
-            else return null;
-        }
-        //Check if the given column is null
-        public function columnCanBeNull($name) {
-            $column = $this->getColumn($name);
-            if ($column != null) return $column->canBeNull == "NULL";
-            else throw new SqlException("Tried checking if column $name can be null, but $name doesnt exist in this column set.");
         }
     }
 

--- a/src/php/mysql.connector/structures/mysql.columns.php
+++ b/src/php/mysql.connector/structures/mysql.columns.php
@@ -129,6 +129,8 @@ namespace MySqlConnector {
             return strpos($thisType, $otherType) > -1 || strpos($otherType, $thisType) > -1;
         }
 
+        public function name() { return $this->name; }
+
         //Return the type for this column, like "VARCHAR(50) NOT NULL"
         public function type() {
             return strtolower("$this->type $this->canBeNull $this->extra");

--- a/src/php/mysql.connector/structures/mysql.columns.php
+++ b/src/php/mysql.connector/structures/mysql.columns.php
@@ -5,10 +5,7 @@ namespace MySqlConnector {
         
         private $columns = array();
         public function __construct($columnsArr) {
-            foreach ($columnsArr as $column) {
-                $colObj = new Column($column);
-                $this->set($colObj->name, $colObj);
-            }
+            foreach ($columnsArr as $column) $this->add(new Column($column));
         }
 
         //Return the name=>type for each column
@@ -30,7 +27,6 @@ namespace MySqlConnector {
 
     class Column extends CompareableObject {
         public 
-            $name,
             $type,
             $isPrimary,
             $canBeNull,
@@ -64,8 +60,6 @@ namespace MySqlConnector {
             $otherType = $other->type();
             return strpos($thisType, $otherType) > -1 || strpos($otherType, $thisType) > -1;
         }
-
-        public function name() { return $this->name; }
 
         //Return the type for this column, like "VARCHAR(50) NOT NULL"
         public function type() {

--- a/src/php/mysql.connector/structures/mysql.columns.php
+++ b/src/php/mysql.connector/structures/mysql.columns.php
@@ -3,7 +3,6 @@
 namespace MySqlConnector {
     class Columns extends CompareableSet {
         
-        private $columns = array();
         public function __construct($columnsArr) {
             foreach ($columnsArr as $column) $this->add(new Column($column));
         }
@@ -11,13 +10,13 @@ namespace MySqlConnector {
         //Return the name=>type for each column
         public function namesAndTypes() {
             $namesAndTypes = array();
-            foreach ($this->columns as $name=>$column) $namesAndTypes[$name] = $column->type();
+            foreach ($this->set as $name=>$column) $namesAndTypes[$name] = $column->type();
             return $namesAndTypes;
         }
         //Return an array of strings used to create these columns
         public function getSqlCreateStrings() {
             $createStrings = array();
-            foreach ($this->columns as $name=>$thisColumn) {
+            foreach ($this->set  as $name=>$thisColumn) {
                 array_push($createStrings, $thisColumn->getCreateString());
                 if ($thisColumn->isPrimary) array_push($createStrings, $thisColumn->getPrimaryKeyString());
             }

--- a/src/php/mysql.connector/structures/mysql.compareable.set.php
+++ b/src/php/mysql.connector/structures/mysql.compareable.set.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace MySqlConnector {
+    abstract class CompareableSet {
+        protected $set = array();
+        
+        public function has($index) { return array_key_exists($index, $this->set); }
+
+        public function get($index) { return $this->has($index) ? $this->set[$index] : null; }
+
+        public function set($key, $value) { $this->set[$key] = $value; }
+
+        public function keys() { return array_keys($this->set); }
+        
+        public function items() { return $this->set; }
+
+        public function count() { return count($this->set); }
+
+        public function compare(CompareableSet $otherSet) {
+            $diff = array();
+
+            //First pass comparing each column in this object (expected columns) to those in the passed object
+            foreach ($this->set as $name=>$thisOne) {
+                //First try fetching this column from $otherColumns
+                $other = $otherSet->get($name);
+                //Check if it exists other $otherColumns
+                $exists = $other != null;
+                //Default to no match
+                $matches = false;
+                //But if it exists, see if it does match
+                if ($exists) {
+                    //Check if this column matches the $otherColumn
+                    $matches = $thisOne->matches($other);
+                }
+                //Define this column in the $columnDifferences
+                $diff[$name] = SetDifference::getInThis($thisOne, $exists, $matches);
+            }
+
+            //Second pass to catch any columns in the other object that dont exist in this one
+            foreach ($otherSet->set as $name=>$otherOne)
+                //Only if this column isnt set in $columnDifferences already
+                if (!isset($diff[$name]))
+                    //Define this as an extra column in the $columnDifferences
+                    $diff[$name] = SetDifference::getInOther($otherOne);
+
+            return $diff;
+        }
+    }
+
+    abstract class CompareableObject {
+        public abstract function matches($other);
+    }
+
+    class SetDifference {
+        private
+            $object,
+            $exists,
+            $matches,
+            $extra;
+        public function __construct(CompareableObject $object, $exists, $matches, $extra) {
+            $this->object = $object;
+            $this->exists = $exists;
+            $this->matches = $matches;
+            $this->extra = $extra;
+        }
+
+        public static function getInThis(CompareableObject $object, $exists, $matches) {
+            return new SetDifference($object, $exists, $matches, false);
+        }
+
+        public static function getInOther(CompareableObject $object) {
+            return new SetDifference($object, false, false, true);
+        }
+
+        public function item() : CompareableObject { return $this->object; }
+        public function exists() { return $this->exists; }
+        public function matches() { return $this->matches; }
+        public function extra() { return $this->extra; }
+    }
+}
+
+?>

--- a/src/php/mysql.connector/structures/mysql.compareable.set.php
+++ b/src/php/mysql.connector/structures/mysql.compareable.set.php
@@ -17,8 +17,14 @@ namespace MySqlConnector {
         public function count() { return count($this->set); }
 
         public function compare(CompareableSet $otherSet) {
-            $diff = array();
+            //First get all objects these two sets share
+            $diff = $this->getSharedObjects($otherSet);
+            //Then add the objects in the $otherSet, but not in this set
+            return $this->addUnknownObjects($otherSet, $diff);
+        }
 
+        private function getSharedObjects(CompareableSet $otherSet) {
+            $diff = array();
             //First pass comparing each column in this object (expected columns) to those in the passed object
             foreach ($this->set as $name=>$thisOne) {
                 //First try fetching this column from $otherColumns
@@ -30,14 +36,16 @@ namespace MySqlConnector {
                 //Define this column in the $columnDifferences
                 $diff[$name] = SetDifference::getInThis($thisOne, $exists, $matches);
             }
+            return $diff;
+        }
 
+        private function addUnknownObjects(CompareableSet $otherSet, $diff) {
             //Second pass to catch any columns in the other object that dont exist in this one
             foreach ($otherSet->set as $name=>$otherOne)
                 //Only if this column isnt set in $columnDifferences already
                 if (!isset($diff[$name]))
                     //Define this as an extra column in the $diff
                     $diff[$name] = SetDifference::getInOther($otherOne);
-
             return $diff;
         }
     }

--- a/src/php/mysql.connector/structures/mysql.compareable.set.php
+++ b/src/php/mysql.connector/structures/mysql.compareable.set.php
@@ -72,7 +72,7 @@ namespace MySqlConnector {
             return new SetDifference($object, false, false, true);
         }
 
-        public function item() : CompareableObject { return $this->object; }
+        public function item() { return $this->object; }
         public function exists() { return $this->exists; }
         public function matches() { return $this->matches; }
         public function extra() { return $this->extra; }

--- a/src/php/mysql.connector/structures/mysql.compareable.set.php
+++ b/src/php/mysql.connector/structures/mysql.compareable.set.php
@@ -8,7 +8,7 @@ namespace MySqlConnector {
 
         public function get($index) { return $this->has($index) ? $this->set[$index] : null; }
 
-        public function set($key, $value) { $this->set[$key] = $value; }
+        public function add(CompareableObject $object) { $this->set[$object->name()] = $object; }
 
         public function keys() { return array_keys($this->set); }
         
@@ -25,13 +25,8 @@ namespace MySqlConnector {
                 $other = $otherSet->get($name);
                 //Check if it exists other $otherColumns
                 $exists = $other != null;
-                //Default to no match
-                $matches = false;
-                //But if it exists, see if it does match
-                if ($exists) {
-                    //Check if this column matches the $otherColumn
-                    $matches = $thisOne->matches($other);
-                }
+                //If this exists in the other set, see if it matches
+                $matches = $exists ? $thisOne->matches($other) : false;
                 //Define this column in the $columnDifferences
                 $diff[$name] = SetDifference::getInThis($thisOne, $exists, $matches);
             }
@@ -40,7 +35,7 @@ namespace MySqlConnector {
             foreach ($otherSet->set as $name=>$otherOne)
                 //Only if this column isnt set in $columnDifferences already
                 if (!isset($diff[$name]))
-                    //Define this as an extra column in the $columnDifferences
+                    //Define this as an extra column in the $diff
                     $diff[$name] = SetDifference::getInOther($otherOne);
 
             return $diff;
@@ -48,6 +43,8 @@ namespace MySqlConnector {
     }
 
     abstract class CompareableObject {
+        public $name;
+        public function name() { return $this->name; }
         public abstract function matches($other);
     }
 

--- a/src/php/mysql.connector/structures/mysql.indexes.php
+++ b/src/php/mysql.connector/structures/mysql.indexes.php
@@ -1,72 +1,20 @@
 <?php
 
 namespace MySqlConnector {
-    class Indexes {
-
-        private $indexes = array();
-
+    class Indexes extends CompareableSet {
         public function __construct($indexesArr) {
             foreach ($indexesArr as $indexRow) {
                 $indexObj = new Index($indexRow);
                 //If the index described by the given row already exists
-                if ($this->hasIndexName($indexObj->name)) //Append it to the existing one (this is a multirow index)
-                    $this->getIndex($indexObj->name)->addColumn($indexObj->columns[0]);
+                if ($this->has($indexObj->name)) //Append it to the existing one (this is a multirow index)
+                    $this->get($indexObj->name)->addColumn($indexObj->columns[0]);
                 else if (!$indexObj->isPrimary()) //Otherwise only add non primary key indexes
-                    $this->indexes[$indexObj->name] = $indexObj;
+                    $this->set($indexObj->name, $indexObj);
             }
         }
-        //Return the index described by the given name
-        public function getIndex($name) {
-            if ($this->hasIndexName($name)) return $this->indexes[$name];
-            else return null;
-        }
-        //Check if the given index name is known
-        public function hasIndexName($name) {
-            return array_key_exists($name, $this->indexes);
-        }
-        //Check if the given index name & columns are known
-        public function hasIndex($name, $columns) {
-            if ($this->hasIndexName($name)) {
-                $index = $this->getIndex($name);
-                if ($index->columns == $columns) return true;
-            }
-            return false;
-        }
-        //Count how many indexes are tracked by this object
-        public function count() { return count($this->indexes); }
-
-        public function compareEach(Indexes $otherIndexes) {
-            $indexDifferences = array();
-
-            //First pass comparing each column in this object (expected columns) to those in the passed object
-            foreach ($this->indexes as $name=>$thisIndex) {
-                //First try fetching this column from $otherColumns
-                $otherIndex = $otherIndexes->getIndex($name);
-                //Check if it exists in $otherColumns
-                $exists = $otherIndex != null;
-                //Check if this column matches the $otherColumn
-                $matches = $thisIndex->columnsMatch($otherIndex);
-                //Define this column in the $columnDifferences
-                $indexDifferences[$name] = self::createIndexDifference($thisIndex->columns, $exists, $matches, false);
-            }
-
-            //Second pass to catch any columns in the other object that dont exist in this one
-            foreach ($otherIndexes->indexes as $name=>$otherIndex)
-                //Only if this column isnt set in $columnDifferences already
-                if (!isset($indexDifferences[$name]))
-                    //Define this as an extra column in the $columnDifferences
-                    $indexDifferences[$name] = self::createIndexDifference($otherIndex->columns, false, false, true);
-
-            return $indexDifferences;
-        }
-
-        private static function createIndexDifference($columns, $exists, $matches, $extra) {
-            return array("columns"=>$columns, "exists"=>$exists, "matches"=>$matches, "extra"=>$extra);
-        }
-
     }
 
-    class Index {
+    class Index extends CompareableObject {
         public
             $nonUnique,
             $name,
@@ -93,8 +41,13 @@ namespace MySqlConnector {
             return $this->name == "PRIMARY";
         }
 
-        public function columnsMatch($otherIndex) {
-            return $this->columns == $otherIndex->columns;
+        public function matches($other) {
+            if ($other == null) return false;
+            else return $this->columns() == $other->columns();
+        }
+
+        public function columns() {
+            return $this->columns;
         }
     }
 }

--- a/src/php/mysql.connector/structures/mysql.indexes.php
+++ b/src/php/mysql.connector/structures/mysql.indexes.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace MySqlConnector {
+    class Indexes {
+
+        private $indexes = array();
+
+        public function __construct($indexesArr) {
+            foreach ($indexesArr as $indexRow) {
+                $indexObj = new Index($indexRow);
+                //If the index described by the given row already exists
+                if ($this->hasIndexName($indexObj->name)) //Append it to the existing one (this is a multirow index)
+                    $this->getIndex($indexObj->name)->addColumn($indexObj->columns[0]);
+                else if (!$indexObj->isPrimary()) //Otherwise only add non primary key indexes
+                    $this->indexes[$indexObj->name] = $indexObj;
+            }
+        }
+        //Return the index described by the given name
+        public function getIndex($name) {
+            if ($this->hasIndexName($name)) return $this->indexes[$name];
+            else return null;
+        }
+        //Check if the given index name is known
+        public function hasIndexName($name) {
+            return array_key_exists($name, $this->indexes);
+        }
+        //Check if the given index name & columns are known
+        public function hasIndex($name, $columns) {
+            if ($this->hasIndexName($name)) {
+                $index = $this->getIndex($name);
+                if ($index->columns == $columns) return true;
+            }
+            return false;
+        }
+        //Count how many indexes are tracked by this object
+        public function count() { return count($this->indexes); }
+
+        public function compareEach(Indexes $otherIndexes) {
+            $indexDifferences = array();
+
+            //First pass comparing each column in this object (expected columns) to those in the passed object
+            foreach ($this->indexes as $name=>$thisIndex) {
+                //First try fetching this column from $otherColumns
+                $otherIndex = $otherIndexes->getIndex($name);
+                //Check if it exists in $otherColumns
+                $exists = $otherIndex != null;
+                //Check if this column matches the $otherColumn
+                $matches = $thisIndex->columnsMatch($otherIndex);
+                //Define this column in the $columnDifferences
+                $indexDifferences[$name] = self::createIndexDifference($thisIndex->columns, $exists, $matches, false);
+            }
+
+            //Second pass to catch any columns in the other object that dont exist in this one
+            foreach ($otherIndexes->indexes as $name=>$otherIndex)
+                //Only if this column isnt set in $columnDifferences already
+                if (!isset($indexDifferences[$name]))
+                    //Define this as an extra column in the $columnDifferences
+                    $indexDifferences[$name] = self::createIndexDifference($otherIndex->columns, false, false, true);
+
+            return $indexDifferences;
+        }
+
+        private static function createIndexDifference($columns, $exists, $matches, $extra) {
+            return array("columns"=>$columns, "exists"=>$exists, "matches"=>$matches, "extra"=>$extra);
+        }
+
+    }
+
+    class Index {
+        public
+            $nonUnique,
+            $name,
+            $columns = array(),
+            $collation,
+            $cardinality,
+            $type,
+            $visible;
+        public function __construct($indexRow) {
+            $this->nonUnique = $indexRow[1];
+            $this->name = $indexRow[2];
+            $this->addColumn($indexRow[4]);
+            $this->collation = $indexRow[5];
+            $this->cardinality = $indexRow[6];
+            $this->type = $indexRow[10];
+            $this->visible = $indexRow[13];
+        }
+
+        public function addColumn($column) {
+            array_push($this->columns, strtolower($column));
+        }
+
+        public function isPrimary() {
+            return $this->name == "PRIMARY";
+        }
+
+        public function columnsMatch($otherIndex) {
+            return $this->columns == $otherIndex->columns;
+        }
+    }
+}
+
+?>

--- a/src/php/mysql.connector/structures/mysql.indexes.php
+++ b/src/php/mysql.connector/structures/mysql.indexes.php
@@ -3,21 +3,21 @@
 namespace MySqlConnector {
     class Indexes extends CompareableSet {
         public function __construct($indexesArr) {
-            foreach ($indexesArr as $indexRow) {
-                $indexObj = new Index($indexRow);
-                //If the index described by the given row already exists
-                if ($this->has($indexObj->name)) //Append it to the existing one (this is a multirow index)
-                    $this->get($indexObj->name)->addColumn($indexObj->columns[0]);
-                else if (!$indexObj->isPrimary()) //Otherwise only add non primary key indexes
-                    $this->set($indexObj->name, $indexObj);
-            }
+            foreach ($indexesArr as $indexRow) $this->handleAddIndex(new Index($indexRow));
+        }
+
+        public function handleAddIndex(Index $index) {
+            //If the index described by the given row already exists
+            if ($this->has($index->name)) //Append it to the existing one (this is a multirow index)
+                $this->get($index->name)->addColumn($index->columns[0]);
+            else if (!$index->isPrimary()) //Otherwise only add non primary key indexes
+                $this->add($index);
         }
     }
 
     class Index extends CompareableObject {
         public
             $nonUnique,
-            $name,
             $columns = array(),
             $collation,
             $cardinality,
@@ -45,8 +45,6 @@ namespace MySqlConnector {
             if ($other == null) return false;
             else return $this->columns() == $other->columns();
         }
-
-        public function name() { return $this->name; }
 
         public function columns() {
             return sprintf("(%s)", implode(",", $this->columns));

--- a/src/php/mysql.connector/structures/mysql.indexes.php
+++ b/src/php/mysql.connector/structures/mysql.indexes.php
@@ -46,8 +46,10 @@ namespace MySqlConnector {
             else return $this->columns() == $other->columns();
         }
 
+        public function name() { return $this->name; }
+
         public function columns() {
-            return $this->columns;
+            return sprintf("(%s)", implode(",", $this->columns));
         }
     }
 }

--- a/src/php/mysql.connector/structures/mysql.schema.enforcer.php
+++ b/src/php/mysql.connector/structures/mysql.schema.enforcer.php
@@ -27,6 +27,9 @@ namespace MySqlConnector {
                 $schemaTableNames[strtolower($name)] = true;
                 //Enforce the known schema onto this table
                 self::enforceTableSchema($name, $columns);
+
+                $indexes = array_key_exists("indexes", $tableSchema) ? $tableSchema["indexes"] : array();
+                self::enforceTableIndexes($name, $indexes);
             }
             //Second pass to drop all tables not listed in the schema
             self::dropUnknownTables($schemaTableNames);
@@ -116,6 +119,34 @@ namespace MySqlConnector {
                 array_push($columnsInDescribeFormat, $column);
             }
             return new Columns($columnsInDescribeFormat);
+        }
+
+        public static function getSchemaIndexesAsObject($schemaIndexes) : Indexes {
+            $IndexesInDescribeFormat = array();
+            foreach ($schemaIndexes as $name=>$indexes) {
+                for ($i = 0;$i < count($indexes);$i++) {
+                    $index = array(1 => 1, 2 => $name, 4 => $indexes[$i], 
+                                   5 => "A", 6 => 0, 10 => "BTREE", 13 => "YES");
+                    array_push($IndexesInDescribeFormat, $index);
+                }
+            }
+            return new Indexes($IndexesInDescribeFormat);
+        }
+
+        private static function getExistingIndexes($name) {
+
+        }
+        
+        private static function enforceTableIndexes($name, $indexes) {
+            //Create an object for this table
+            $table = new Table($name);
+            $existingIndexes = $table->indexes();
+            $schemaIndexes = self::getSchemaIndexesAsObject($indexes);
+            if ($existingIndexes->count() > 0 || $schemaIndexes->count() > 0) {
+                var_dump($name);
+                var_dump($existingIndexes);
+                var_dump($schemaIndexes);
+            }
         }
     }
 }

--- a/src/php/mysql.connector/structures/mysql.schema.enforcer.php
+++ b/src/php/mysql.connector/structures/mysql.schema.enforcer.php
@@ -21,6 +21,7 @@ namespace MySqlConnector {
             self::debugPrint($operation);
             array_push(self::$operations, $operation); 
         }
+
         public static function getDBOperationsList() { return self::$operations; }
 
         public function enforceSchema() {

--- a/src/php/mysql.connector/structures/mysql.schema.enforcer.php
+++ b/src/php/mysql.connector/structures/mysql.schema.enforcer.php
@@ -133,9 +133,6 @@ namespace MySqlConnector {
             return new Indexes($IndexesInDescribeFormat);
         }
 
-        private static function getExistingIndexes($name) {
-
-        }
         
         private static function enforceTableIndexes($name, $indexes) {
             //Create an object for this table
@@ -144,8 +141,7 @@ namespace MySqlConnector {
             $schemaIndexes = self::getSchemaIndexesAsObject($indexes);
             if ($existingIndexes->count() > 0 || $schemaIndexes->count() > 0) {
                 var_dump($name);
-                var_dump($existingIndexes);
-                var_dump($schemaIndexes);
+                var_dump($schemaIndexes->compare($existingIndexes));
             }
         }
     }

--- a/src/php/mysql.connector/structures/mysql.table.php
+++ b/src/php/mysql.connector/structures/mysql.table.php
@@ -160,7 +160,7 @@ namespace MySqlConnector {
         }
 
 
-        
+
         public function alterColumn($type, Column $column) {
             $sql = "ALTER TABLE `$this->name` ";
             switch ($type) {
@@ -193,6 +193,10 @@ namespace MySqlConnector {
                     $sql = "DROP INDEX %s ON `$this->name`"; 
                     $sql = sprintf($sql, $index->name());
                     break;
+                case AlterType::MODIFY:
+                    $this->alterIndex(AlterType::DROP, $index);
+                    $this->alterIndex(AlterType::ADD, $index);
+                    return;
                 default: throw new SqlException("Unknown or unsupported index alter type '$type' for table $this->name. Use ADD, DROP.");
             }
             $this->tableIndexes == null;

--- a/src/php/mysql.connector/structures/mysql.table.php
+++ b/src/php/mysql.connector/structures/mysql.table.php
@@ -161,7 +161,7 @@ namespace MySqlConnector {
 
 
 
-        public function alterColumn(AlterType $type, Column $column) {
+        public function alterColumn($type, Column $column) {
             $sql = "ALTER TABLE `$this->name` ";
             switch ($type) {
                 case AlterType::ADD:    

--- a/src/php/mysql.connector/structures/mysql.table.php
+++ b/src/php/mysql.connector/structures/mysql.table.php
@@ -160,7 +160,7 @@ namespace MySqlConnector {
         }
 
 
-
+        
         public function alterColumn($type, Column $column) {
             $sql = "ALTER TABLE `$this->name` ";
             switch ($type) {
@@ -181,23 +181,6 @@ namespace MySqlConnector {
             $this->tableColumns == null;
             return Query::runActionQuery($sql);
         }
-
-        //Where $type is one of: ADD, DROP, MODIFY
-        public function alter($type, $columnName, $columnDescription = null) {
-            $sql = "ALTER TABLE `$this->name`";
-            switch ($type) {
-                case AlterType::ADD:    $sql .= " ADD $columnName $columnDescription"; break;
-                case AlterType::DROP:   $sql .= " DROP COLUMN $columnName"; break;
-                case AlterType::MODIFY: $sql .= " MODIFY COLUMN $columnName $columnDescription"; break;
-                default: throw new SqlException("Unknown alter type '$type' for table $this->name. Use ADD, DROP, or MODIFY.");
-            }
-            $this->tableColumns == null;
-            return Query::runActionQuery($sql);
-        }
-        //Alias's for the alter function
-        public function addColumn($columnName, $columnDescription) { return $this->alter(AlterType::ADD, $columnName, $columnDescription); }
-        public function dropColumn($columnName) { return $this->alter(AlterType::DROP, $columnName); }
-        public function modifyColumn($columnName, $columnDescription) { return $this->alter(AlterType::MODIFY, $columnName, $columnDescription); }
 
         public function alterIndex($type, Index $index) {
             $sql = "";

--- a/src/php/mysql.connector/structures/mysql.table.php
+++ b/src/php/mysql.connector/structures/mysql.table.php
@@ -160,23 +160,68 @@ namespace MySqlConnector {
         }
 
 
+
+        public function alterColumn(AlterType $type, Column $column) {
+            $sql = "ALTER TABLE `$this->name` ";
+            switch ($type) {
+                case AlterType::ADD:    
+                    $sql .= "ADD %s %s"; 
+                    $sql = sprintf($sql, $column->name(), $column->type());
+                    break;
+                case AlterType::DROP:
+                    $sql .= "DROP COLUMN %s"; 
+                    $sql = sprintf($sql, $column->name());
+                    break;
+                case AlterType::MODIFY:
+                    $sql .= "MODIFY COLUMN %s %s"; 
+                    $sql = sprintf($sql, $column->name(), $column->type());
+                    break;
+                default: throw new SqlException("Unknown or unsupported column alter type '$type' for table $this->name. Use ADD, DROP, or MODIFY.");
+            }
+            $this->tableColumns == null;
+            return Query::runActionQuery($sql);
+        }
+
         //Where $type is one of: ADD, DROP, MODIFY
         public function alter($type, $columnName, $columnDescription = null) {
             $sql = "ALTER TABLE `$this->name`";
             switch ($type) {
-                case "ADD":    $sql .= " ADD $columnName $columnDescription"; break;
-                case "DROP":   $sql .= " DROP COLUMN $columnName"; break;
-                case "MODIFY": $sql .= " MODIFY COLUMN $columnName $columnDescription"; break;
+                case AlterType::ADD:    $sql .= " ADD $columnName $columnDescription"; break;
+                case AlterType::DROP:   $sql .= " DROP COLUMN $columnName"; break;
+                case AlterType::MODIFY: $sql .= " MODIFY COLUMN $columnName $columnDescription"; break;
                 default: throw new SqlException("Unknown alter type '$type' for table $this->name. Use ADD, DROP, or MODIFY.");
             }
             $this->tableColumns == null;
             return Query::runActionQuery($sql);
         }
         //Alias's for the alter function
-        public function addColumn($columnName, $columnDescription) { return $this->alter("ADD", $columnName, $columnDescription); }
-        public function dropColumn($columnName) { return $this->alter("DROP", $columnName); }
-        public function modifyColumn($columnName, $columnDescription) { return $this->alter("MODIFY", $columnName, $columnDescription); }
-    } 
+        public function addColumn($columnName, $columnDescription) { return $this->alter(AlterType::ADD, $columnName, $columnDescription); }
+        public function dropColumn($columnName) { return $this->alter(AlterType::DROP, $columnName); }
+        public function modifyColumn($columnName, $columnDescription) { return $this->alter(AlterType::MODIFY, $columnName, $columnDescription); }
+
+        public function alterIndex($type, Index $index) {
+            $sql = "";
+            switch ($type) {
+                case AlterType::ADD:
+                    $sql = "ALTER TABLE `$this->name` ADD INDEX %s %s";
+                    $sql = sprintf($sql, $index->name(), $index->columns());
+                    break;
+                case AlterType::DROP:
+                    $sql = "DROP INDEX %s ON `$this->name`"; 
+                    $sql = sprintf($sql, $index->name());
+                    break;
+                default: throw new SqlException("Unknown or unsupported index alter type '$type' for table $this->name. Use ADD, DROP.");
+            }
+            $this->tableIndexes == null;
+            return Query::runActionQuery($sql);
+        }
+    }
+
+    abstract class AlterType {
+        const ADD = "ADD";
+        const DROP = "DROP";
+        const MODIFY = "MODIFY";
+    }
 }
 
 ?>

--- a/src/php/mysql.connector/structures/mysql.table.php
+++ b/src/php/mysql.connector/structures/mysql.table.php
@@ -159,8 +159,6 @@ namespace MySqlConnector {
             return Query::runActionQuery($sql);
         }
 
-
-
         public function alterColumn($type, Column $column) {
             $sql = "ALTER TABLE `$this->name` ";
             switch ($type) {
@@ -202,12 +200,26 @@ namespace MySqlConnector {
             $this->tableIndexes == null;
             return Query::runActionQuery($sql);
         }
+
+        public function alter($structure, $type, $withObject) {
+            switch ($structure) {
+                case AlterStructure::COLUMN: $this->alterColumn($type, $withObject); break;
+                case AlterStructure::INDEX: $this->alterIndex($type, $withObject); break;
+                default: throw new SqlException("Unknown or unsupported alter structure '$structure' for table $this->name. Use COLUMN or INDEX.");
+            }
+        }
+
     }
 
     abstract class AlterType {
         const ADD = "ADD";
         const DROP = "DROP";
         const MODIFY = "MODIFY";
+    }
+
+    abstract class AlterStructure {
+        const INDEX = "INDEX";
+        const COLUMN = "COLUMN";
     }
 }
 

--- a/src/php/mysql.connector/structures/mysql.table.php
+++ b/src/php/mysql.connector/structures/mysql.table.php
@@ -5,7 +5,8 @@ namespace MySqlConnector {
     class Table {
         private 
             $tableExists = null,
-            $tableColumns = null;
+            $tableColumns = null,
+            $tableIndexes = null;
         private ?Columns $columns = null;
         public $name;
         
@@ -41,6 +42,15 @@ namespace MySqlConnector {
                 $this->columns = new Columns($results);
             }
             return $this->columns;
+        }
+        //Show the indexes setup on this table
+        public function indexes() {
+            $sql = "SHOW INDEX FROM `$this->name`";
+            if ($this->tableIndexes == null) {
+                $results = Query::runQuery($sql);
+                $this->tableIndexes = new Indexes($results);
+            }
+            return $this->tableIndexes;
         }
         //Count the number of rows in this table
         public function count($whereCondition = null) {


### PR DESCRIPTION
Add index support to the schema format & enforcer.

At the same time, refactor very similar code to add/drop/modify columns to be used generally for indexes as well.

closes #56 
Adds to #19 with indexes