### PR TITLE
Refactor table integrations

### DIFF
--- a/audit.congress.schema.json
+++ b/audit.congress.schema.json
@@ -107,7 +107,7 @@
             {
                 "name": "MemberOffices",
                 "columns": {
-                    "officeId": { "type": "VARCHAR(100)", "null": "NO", "primary": true  },
+                    "id": { "type": "VARCHAR(100)", "null": "NO", "primary": true  },
                     "bioguideId": { "type": "VARCHAR(50)", "null": "NO"},
                     
                     "address": { "type": "VARCHAR(250)", "null": "YES" },

--- a/src/api/api.php
+++ b/src/api/api.php
@@ -17,7 +17,7 @@ if ($route !== null) {
         case "cosponsors":
         case "titles":
         case "subjects":
-        case "member":
+        case "members":
         case "terms":
         case "socials":
         case "offices":

--- a/src/api/test/mysql.connector.test.php
+++ b/src/api/test/mysql.connector.test.php
@@ -29,12 +29,18 @@ namespace APITest {
 
         static function testInsertRow($tableName) {
             $table = new \MySqlConnector\Table($tableName);
-            var_dump($table->insert(["id", "name", "test", "tes3"], [((int)rand()), "namehere", "test", "x3"]));
+            $cols = ["id", "name", "test", "tes3"];
+            $vals = [((int)rand()), "namehere", "test", "x3"];
+            $row = \MySqlConnector\SqlRow::fromColsAndVals($cols, $vals); 
+            var_dump($table->insert($row));
         }
 
         static function testUpdateRow($tableName) {
             $table = new \MySqlConnector\Table($tableName);
-            var_dump($table->update(["id", "name", "test", "tes3"], [11, "dabba","updateddhfjajkld","here"], "id = 11"));
+            $cols = ["id", "name", "test", "tes3"];
+            $vals = [11, "dabba","updateddhfjajkld","here"];
+            $row = \MySqlConnector\SqlRow::fromColsAndVals($cols, $vals); 
+            var_dump($table->update($row, "id = 11"));
         }
 
         static function testDeleteRow($tableName) {

--- a/src/php/api/routes/bills/class.bills.by.id.php
+++ b/src/php/api/routes/bills/class.bills.by.id.php
@@ -12,11 +12,11 @@ namespace API {
     }
     class BillsBySponsorId extends BillsRoute {
 
-        public static function parameters() { return ["sponsorId"]; }
+        public static function parameters() { return ["bioguideId"]; }
         
         public static function fetchResult() {
-            $id = Parameters::get("sponsorId");
-            return \AuditCongress\Bills::getBySponsorId($id);
+            $id = Parameters::get("bioguideId");
+            return \AuditCongress\Bills::getByBioguideId($id);
         }
     }
 }

--- a/src/php/api/routes/member/class.member.by.bioguide.id.php
+++ b/src/php/api/routes/member/class.member.by.bioguide.id.php
@@ -3,11 +3,11 @@
 namespace API {
     class MemberByBioguideId extends MemberRoute {
 
-        public static function parameters() { return ["id"]; }
+        public static function parameters() { return ["bioguideId"]; }
         
         public static function fetchResult() {
-            $id = Parameters::get("id");
-            return \AuditCongress\Members::getByBioguideId($id);
+            $bioguideId = Parameters::get("bioguideId");
+            return \AuditCongress\Members::getByBioguideId($bioguideId);
         }
     }
 }

--- a/src/php/api/routes/member/class.member.by.bioguide.id.php
+++ b/src/php/api/routes/member/class.member.by.bioguide.id.php
@@ -3,10 +3,10 @@
 namespace API {
     class MemberByBioguideId extends MemberRoute {
 
-        public static function parameters() { return ["bioguideId"]; }
+        public static function parameters() { return ["id"]; }
         
         public static function fetchResult() {
-            $bioguideId = Parameters::get("bioguideId");
+            $bioguideId = Parameters::get("id");
             return \AuditCongress\Members::getByBioguideId($bioguideId);
         }
     }

--- a/src/php/api/routes/member/class.member.php
+++ b/src/php/api/routes/member/class.member.php
@@ -3,7 +3,7 @@
 namespace API {
     class Member extends RouteGroup {
         private function __construct() {
-            parent::__construct("member", "\API\MemberRoute");
+            parent::__construct("members", "\API\MemberRoute");
         }
 
         private static $memberInstance = null;

--- a/src/php/api/routes/offices/class.offices.by.bioguide.id.php
+++ b/src/php/api/routes/offices/class.offices.by.bioguide.id.php
@@ -3,11 +3,11 @@
 namespace API {
     class OfficesByBioguideId extends OfficesRoute {
 
-        public static function parameters() { return ["id"]; }
+        public static function parameters() { return ["bioguideId"]; }
         
         public static function fetchResult() {
-            $id = Parameters::get("id");
-            return \AuditCongress\MemberOffices::getByBioguideId($id);
+            $bioguideId = Parameters::get("bioguideId");
+            return \AuditCongress\MemberOffices::getByBioguideId($bioguideId);
         }
     }
 }

--- a/src/php/api/routes/offices/class.offices.by.office.id.php
+++ b/src/php/api/routes/offices/class.offices.by.office.id.php
@@ -3,11 +3,11 @@
 namespace API {
     class OfficesByOfficeId extends OfficesRoute {
 
-        public static function parameters() { return ["officeid"]; }
+        public static function parameters() { return ["id"]; }
         
         public static function fetchResult() {
-            $officeid = Parameters::get("officeid");
-            return \AuditCongress\MemberOffices::getByOfficeId($officeid);
+            $id = Parameters::get("id");
+            return \AuditCongress\MemberOffices::getById($id);
         }
     }
 }

--- a/src/php/audit.congress/objects/bills/autoload.php
+++ b/src/php/audit.congress/objects/bills/autoload.php
@@ -1,6 +1,6 @@
 <?php
 require_once AUDITCONGRESS_FOLDER."\objects\bills\class.bill.table.php";
-require_once AUDITCONGRESS_FOLDER."\objects\bills\class.bill.query.php";
+require_once AUDITCONGRESS_FOLDER."\objects\bills\class.bill.query.traits.php";
 
 require_once AUDITCONGRESS_FOLDER."\objects\bills\\tables\class.bills.php";
 require_once AUDITCONGRESS_FOLDER."\objects\bills\\tables\class.bill.titles.php";

--- a/src/php/audit.congress/objects/bills/class.bill.query.traits.php
+++ b/src/php/audit.congress/objects/bills/class.bill.query.traits.php
@@ -1,13 +1,6 @@
 <?php
 
 namespace AuditCongress {
-    trait BillsGetByIdQuery {
-
-        public static function getById($id) {
-            $query = self::getWithSearchSelect("id", "=", $id);
-            return $query->selectFromDB()->fetchAllAssoc();
-        }
-    }
     trait BillsGetByBillIdQuery {
 
         public static function getByBillId($billid) {

--- a/src/php/audit.congress/objects/bills/class.bill.query.traits.php
+++ b/src/php/audit.congress/objects/bills/class.bill.query.traits.php
@@ -17,15 +17,6 @@ namespace AuditCongress {
             return $query->selectFromDB()->fetchAllAssoc();
         }
     }
-    trait BillsGetByBioguideIdQuery {
-
-        public static function getByBioguideId($bioguideId) {
-            $query = self::getWithSearchSelect("bioguideId", "=", $bioguideId);
-            $query->applyDefaultOrder();
-            $query->applyPagination();
-            return $query->selectFromDB()->fetchAllAssoc();
-        }
-    }
     trait BillsGetWithFilterQuery {
 
         public static function getWithFilterPlusOne($congress = null, $type = null, $number = null, $likeSearchColumn = null, $likeSearchValue = null) {

--- a/src/php/audit.congress/objects/bills/class.bill.query.traits.php
+++ b/src/php/audit.congress/objects/bills/class.bill.query.traits.php
@@ -1,12 +1,6 @@
 <?php
 
 namespace AuditCongress {
-
-    abstract class BillQuery extends AuditCongressQuery {
-
-        public abstract function applyDefaultOrder();
-    }
-
     trait BillsGetByIdQuery {
 
         public static function getById($id) {
@@ -14,7 +8,6 @@ namespace AuditCongress {
             return $query->selectFromDB()->fetchAllAssoc();
         }
     }
-    
     trait BillsGetByBillIdQuery {
 
         public static function getByBillId($billid) {
@@ -24,7 +17,6 @@ namespace AuditCongress {
             return $query->selectFromDB()->fetchAllAssoc();
         }
     }
-
     trait BillsGetByBioguideIdQuery {
 
         public static function getByBioguideId($bioguideId) {
@@ -34,7 +26,6 @@ namespace AuditCongress {
             return $query->selectFromDB()->fetchAllAssoc();
         }
     }
-
     trait BillsGetWithFilterQuery {
 
         public static function getWithFilterPlusOne($congress = null, $type = null, $number = null, $likeSearchColumn = null, $likeSearchValue = null) {

--- a/src/php/audit.congress/objects/bills/class.bill.table.php
+++ b/src/php/audit.congress/objects/bills/class.bill.table.php
@@ -4,8 +4,8 @@ namespace AuditCongress {
 
     abstract class BillTable extends CacheTrackedTable {
 
-        public function __construct($tableName) {
-            parent::__construct($tableName, "bulk-bill");
+        public function __construct($tableName, $queryClassName = null) {
+            parent::__construct($tableName, $queryClassName, "bulk-bill");
         }
 
         public function updateCache() { 
@@ -15,6 +15,30 @@ namespace AuditCongress {
         public static abstract function getInstance();
 
         protected static abstract function parseResult($resultRows);
+    }
+
+
+    //Traits to use in the tables extending BillTable
+    trait BillsGetById {
+        public static function getById($id) {
+            self::enforceCache();
+            $items = self::getQueryClass()::getById($id);
+            return self::returnFirst(self::parseResult($items));
+        }
+    }
+    trait BillsGetByBioguideId {
+        public static function getByBioguideId($bioguideId) {
+            self::enforceCache();
+            $items = self::getQueryClass()::getByBioguideId($bioguideId);
+            return self::parseResult($items);
+        }
+    }
+    trait BillsGetByBillId {
+        public static function getByBillId($billId) {
+            self::enforceCache();
+            $items = self::getQueryClass()::getByBillId($billId);
+            return self::parseResult($items);
+        }
     }
 }
 

--- a/src/php/audit.congress/objects/bills/class.bill.table.php
+++ b/src/php/audit.congress/objects/bills/class.bill.table.php
@@ -11,10 +11,6 @@ namespace AuditCongress {
         public function updateCache() { 
             $this->cacheTracker->runUpdateScript(true, null, null); 
         }
-        
-        public static abstract function getInstance();
-
-        protected static abstract function parseResult($resultRows);
     }
 
 

--- a/src/php/audit.congress/objects/bills/class.bill.table.php
+++ b/src/php/audit.congress/objects/bills/class.bill.table.php
@@ -15,20 +15,6 @@ namespace AuditCongress {
 
 
     //Traits to use in the tables extending BillTable
-    trait BillsGetById {
-        public static function getById($id) {
-            self::enforceCache();
-            $items = self::getQueryClass()::getById($id);
-            return self::returnFirst(self::parseResult($items));
-        }
-    }
-    trait BillsGetByBioguideId {
-        public static function getByBioguideId($bioguideId) {
-            self::enforceCache();
-            $items = self::getQueryClass()::getByBioguideId($bioguideId);
-            return self::parseResult($items);
-        }
-    }
     trait BillsGetByBillId {
         public static function getByBillId($billId) {
             self::enforceCache();

--- a/src/php/audit.congress/objects/bills/class.bill.table.php
+++ b/src/php/audit.congress/objects/bills/class.bill.table.php
@@ -4,8 +4,8 @@ namespace AuditCongress {
 
     abstract class BillTable extends CacheTrackedTable {
 
-        public function __construct($tableName, $queryClassName = null) {
-            parent::__construct($tableName, $queryClassName, "bulk-bill");
+        public function __construct($tableName, $queryClassName = null, $rowClassName = null) {
+            parent::__construct($tableName, $queryClassName, $rowClassName, "bulk-bill");
         }
 
         public function updateCache() { 

--- a/src/php/audit.congress/objects/bills/class.bill.table.php
+++ b/src/php/audit.congress/objects/bills/class.bill.table.php
@@ -5,7 +5,8 @@ namespace AuditCongress {
     abstract class BillTable extends CacheTrackedTable {
 
         public function __construct($tableName, $queryClassName = null, $rowClassName = null) {
-            parent::__construct($tableName, $queryClassName, $rowClassName, "bulk-bill");
+            parent::__construct($tableName, $queryClassName, $rowClassName);
+            $this->setTrackedCache("bulk-bill");
         }
 
         public function updateCache() { 

--- a/src/php/audit.congress/objects/bills/querys/class.bill.cosponsors.query.php
+++ b/src/php/audit.congress/objects/bills/querys/class.bill.cosponsors.query.php
@@ -4,7 +4,7 @@ namespace AuditCongress {
 
     class BillCosponsorsQuery extends AuditCongressQuery {
 
-        use BillsGetByIdQuery, BillsGetByBillIdQuery, BillsGetByBioguideIdQuery, BillsGetWithFilterQuery;
+        use BillsGetByIdQuery, BillsGetByBillIdQuery, GetByBioguideIdQuery, BillsGetWithFilterQuery;
 
         public function __construct() {
             parent::__construct("BillCosponsors");

--- a/src/php/audit.congress/objects/bills/querys/class.bill.cosponsors.query.php
+++ b/src/php/audit.congress/objects/bills/querys/class.bill.cosponsors.query.php
@@ -4,7 +4,7 @@ namespace AuditCongress {
 
     class BillCosponsorsQuery extends AuditCongressQuery {
 
-        use BillsGetByIdQuery, BillsGetByBillIdQuery, GetByBioguideIdQuery, BillsGetWithFilterQuery;
+        use GetByIdQuery, BillsGetByBillIdQuery, GetByBioguideIdQuery, BillsGetWithFilterQuery;
 
         public function __construct() {
             parent::__construct("BillCosponsors");

--- a/src/php/audit.congress/objects/bills/querys/class.bill.cosponsors.query.php
+++ b/src/php/audit.congress/objects/bills/querys/class.bill.cosponsors.query.php
@@ -2,7 +2,7 @@
 
 namespace AuditCongress {
 
-    class BillCosponsorsQuery extends BillQuery {
+    class BillCosponsorsQuery extends AuditCongressQuery {
 
         use BillsGetByIdQuery, BillsGetByBillIdQuery, BillsGetByBioguideIdQuery, BillsGetWithFilterQuery;
 

--- a/src/php/audit.congress/objects/bills/querys/class.bill.subjects.query.php
+++ b/src/php/audit.congress/objects/bills/querys/class.bill.subjects.query.php
@@ -2,7 +2,7 @@
 
 namespace AuditCongress {
 
-    class BillSubjectsQuery extends BillQuery {
+    class BillSubjectsQuery extends AuditCongressQuery {
 
         use BillsGetByIdQuery, BillsGetByBillIdQuery, BillsGetWithFilterQuery;
 

--- a/src/php/audit.congress/objects/bills/querys/class.bill.subjects.query.php
+++ b/src/php/audit.congress/objects/bills/querys/class.bill.subjects.query.php
@@ -4,7 +4,7 @@ namespace AuditCongress {
 
     class BillSubjectsQuery extends AuditCongressQuery {
 
-        use BillsGetByIdQuery, BillsGetByBillIdQuery, BillsGetWithFilterQuery;
+        use GetByIdQuery, BillsGetByBillIdQuery, BillsGetWithFilterQuery;
 
         public function __construct() {
             parent::__construct("BillSubjects");

--- a/src/php/audit.congress/objects/bills/querys/class.bill.titles.query.php
+++ b/src/php/audit.congress/objects/bills/querys/class.bill.titles.query.php
@@ -2,7 +2,7 @@
 
 namespace AuditCongress {
 
-    class BillTitlesQuery extends BillQuery {
+    class BillTitlesQuery extends AuditCongressQuery {
 
         use BillsGetByIdQuery, BillsGetByBillIdQuery, BillsGetWithFilterQuery;
 

--- a/src/php/audit.congress/objects/bills/querys/class.bill.titles.query.php
+++ b/src/php/audit.congress/objects/bills/querys/class.bill.titles.query.php
@@ -4,7 +4,7 @@ namespace AuditCongress {
 
     class BillTitlesQuery extends AuditCongressQuery {
 
-        use BillsGetByIdQuery, BillsGetByBillIdQuery, BillsGetWithFilterQuery;
+        use GetByIdQuery, BillsGetByBillIdQuery, BillsGetWithFilterQuery;
 
         public function __construct() {
             parent::__construct("BillTitles");

--- a/src/php/audit.congress/objects/bills/querys/class.bills.query.php
+++ b/src/php/audit.congress/objects/bills/querys/class.bills.query.php
@@ -4,7 +4,7 @@ namespace AuditCongress {
 
     class BillsQuery extends AuditCongressQuery {
         
-        use BillsGetByIdQuery, GetByBioguideIdQuery, BillsGetWithFilterQuery;
+        use GetByIdQuery, GetByBioguideIdQuery, BillsGetWithFilterQuery;
 
         public function __construct() {
             parent::__construct("Bills");

--- a/src/php/audit.congress/objects/bills/querys/class.bills.query.php
+++ b/src/php/audit.congress/objects/bills/querys/class.bills.query.php
@@ -4,7 +4,7 @@ namespace AuditCongress {
 
     class BillsQuery extends AuditCongressQuery {
         
-        use BillsGetByIdQuery, BillsGetByBioguideIdQuery, BillsGetWithFilterQuery;
+        use BillsGetByIdQuery, GetByBioguideIdQuery, BillsGetWithFilterQuery;
 
         public function __construct() {
             parent::__construct("Bills");

--- a/src/php/audit.congress/objects/bills/querys/class.bills.query.php
+++ b/src/php/audit.congress/objects/bills/querys/class.bills.query.php
@@ -2,7 +2,7 @@
 
 namespace AuditCongress {
 
-    class BillsQuery extends BillQuery {
+    class BillsQuery extends AuditCongressQuery {
         
         use BillsGetByIdQuery, BillsGetByBioguideIdQuery, BillsGetWithFilterQuery;
 

--- a/src/php/audit.congress/objects/bills/tables/class.bill.cosponsors.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bill.cosponsors.php
@@ -4,8 +4,10 @@ namespace AuditCongress {
 
     class BillCosponsors extends BillTable {
 
+        use BillsGetById, BillsGetByBillId, BillsGetByBioguideId;
+
         private function __construct() {
-            parent::__construct("BillCosponsors");
+            parent::__construct("BillCosponsors", "\AuditCongress\BillCosponsorsQuery");
         }
 
         private static $billsObject = null;
@@ -18,24 +20,6 @@ namespace AuditCongress {
         protected static function parseResult($rows) {
             $rows = BillCosponsorRow::rowsToObjects($rows);
             return $rows;
-        }
-
-        public static function getById($billCosponsorId) {
-            self::enforceCache();
-            $cosponsor = BillCosponsorsQuery::getById($billCosponsorId);
-            return self::returnFirst(self::parseResult($cosponsor));
-        }
-
-        public static function getByBillId($billId) {
-            self::enforceCache();
-            $cosponsor = BillCosponsorsQuery::getByBillId($billId);
-            return self::parseResult($cosponsor);
-        }
-
-        public static function getByBioguideId($biobuideId) {
-            self::enforceCache();
-            $cosponsor = BillCosponsorsQuery::getByBioguideId($biobuideId);
-            return self::parseResult($cosponsor);
         }
 
         public static function getByFilter($congress = null, $type = null, $number = null, $bioguideId = null, $sort = ["sponsoredAt"]) {

--- a/src/php/audit.congress/objects/bills/tables/class.bill.cosponsors.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bill.cosponsors.php
@@ -4,7 +4,7 @@ namespace AuditCongress {
 
     class BillCosponsors extends BillTable {
 
-        use BillsGetById, BillsGetByBillId, BillsGetByBioguideId;
+        use GetById, BillsGetByBillId, GetByBioguideId;
 
         private function __construct() {
             parent::__construct("BillCosponsors", "\AuditCongress\BillCosponsorsQuery");

--- a/src/php/audit.congress/objects/bills/tables/class.bill.cosponsors.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bill.cosponsors.php
@@ -7,7 +7,7 @@ namespace AuditCongress {
         use GetById, BillsGetByBillId, GetByBioguideId;
 
         private function __construct() {
-            parent::__construct("BillCosponsors", "\AuditCongress\BillCosponsorsQuery");
+            parent::__construct("BillCosponsors", "BillCosponsorsQuery", "BillCosponsorRow");
         }
 
         private static $billsObject = null;
@@ -15,11 +15,6 @@ namespace AuditCongress {
             if (self::$billsObject == null) 
                 self::$billsObject = new BillCosponsors();
             return self::$billsObject;
-        }
-
-        protected static function parseResult($rows) {
-            $rows = BillCosponsorRow::rowsToObjects($rows);
-            return $rows;
         }
 
         public static function getByFilter($congress = null, $type = null, $number = null, $bioguideId = null, $sort = ["sponsoredAt"]) {

--- a/src/php/audit.congress/objects/bills/tables/class.bill.subjects.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bill.subjects.php
@@ -4,8 +4,10 @@ namespace AuditCongress {
 
     class BillSubjects extends BillTable {
 
+        use BillsGetById, BillsGetByBillId;
+
         private function __construct() {
-            parent::__construct("BillSubjects");
+            parent::__construct("BillSubjects", "\AuditCongress\BillSubjectsQuery");
         }
 
         private static $billsObject = null;
@@ -18,18 +20,6 @@ namespace AuditCongress {
         protected static function parseResult($rows) {
             $rows = BillSubjectRow::rowsToObjects($rows);
             return $rows;
-        }
-
-        public static function getById($billSubjectId) {
-            self::enforceCache();
-            $subject = BillSubjectsQuery::getById($billSubjectId);
-            return self::returnFirst(self::parseResult($subject));
-        }
-
-        public static function getByBillId($billId) {
-            self::enforceCache();
-            $subjects = BillSubjectsQuery::getByBillId($billId);
-            return self::parseResult($subjects);
         }
 
         public static function getByFilter($congress = null, $type = null, $number = null, $subject = null) {

--- a/src/php/audit.congress/objects/bills/tables/class.bill.subjects.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bill.subjects.php
@@ -7,7 +7,7 @@ namespace AuditCongress {
         use GetById, BillsGetByBillId;
 
         private function __construct() {
-            parent::__construct("BillSubjects", "\AuditCongress\BillSubjectsQuery");
+            parent::__construct("BillSubjects", "BillSubjectsQuery", "BillSubjectRow");
         }
 
         private static $billsObject = null;
@@ -15,11 +15,6 @@ namespace AuditCongress {
             if (self::$billsObject == null) 
                 self::$billsObject = new BillSubjects();
             return self::$billsObject;
-        }
-
-        protected static function parseResult($rows) {
-            $rows = BillSubjectRow::rowsToObjects($rows);
-            return $rows;
         }
 
         public static function getByFilter($congress = null, $type = null, $number = null, $subject = null) {

--- a/src/php/audit.congress/objects/bills/tables/class.bill.subjects.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bill.subjects.php
@@ -4,7 +4,7 @@ namespace AuditCongress {
 
     class BillSubjects extends BillTable {
 
-        use BillsGetById, BillsGetByBillId;
+        use GetById, BillsGetByBillId;
 
         private function __construct() {
             parent::__construct("BillSubjects", "\AuditCongress\BillSubjectsQuery");

--- a/src/php/audit.congress/objects/bills/tables/class.bill.titles.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bill.titles.php
@@ -4,8 +4,10 @@ namespace AuditCongress {
 
     class BillTitles extends BillTable {
 
+        use BillsGetById, BillsGetByBillId;
+
         private function __construct() {
-            parent::__construct("BillTitles");
+            parent::__construct("BillTitles", "\AuditCongress\BillTitlesQuery");
         }
 
         private static $billsObject = null;
@@ -18,18 +20,6 @@ namespace AuditCongress {
         protected static function parseResult($rows) {
             $rows = BillTitleRow::rowsToObjects($rows);
             return $rows;
-        }
-
-        public static function getById($billTitleId) {
-            self::enforceCache();
-            $title = BillTitlesQuery::getById($billTitleId);
-            return self::returnFirst(self::parseResult($title));
-        }
-
-        public static function getByBillId($billId) {
-            self::enforceCache();
-            $titles = BillTitlesQuery::getByBillId($billId);
-            return self::parseResult($titles);
         }
 
         public static function getByFilter($congress = null, $type = null, $number = null, $title = null) {

--- a/src/php/audit.congress/objects/bills/tables/class.bill.titles.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bill.titles.php
@@ -7,7 +7,7 @@ namespace AuditCongress {
         use GetById, BillsGetByBillId;
 
         private function __construct() {
-            parent::__construct("BillTitles", "\AuditCongress\BillTitlesQuery");
+            parent::__construct("BillTitles", "BillTitlesQuery", "BillTitleRow");
         }
 
         private static $billsObject = null;
@@ -15,11 +15,6 @@ namespace AuditCongress {
             if (self::$billsObject == null) 
                 self::$billsObject = new BillTitles();
             return self::$billsObject;
-        }
-
-        protected static function parseResult($rows) {
-            $rows = BillTitleRow::rowsToObjects($rows);
-            return $rows;
         }
 
         public static function getByFilter($congress = null, $type = null, $number = null, $title = null) {

--- a/src/php/audit.congress/objects/bills/tables/class.bill.titles.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bill.titles.php
@@ -4,7 +4,7 @@ namespace AuditCongress {
 
     class BillTitles extends BillTable {
 
-        use BillsGetById, BillsGetByBillId;
+        use GetById, BillsGetByBillId;
 
         private function __construct() {
             parent::__construct("BillTitles", "\AuditCongress\BillTitlesQuery");

--- a/src/php/audit.congress/objects/bills/tables/class.bills.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bills.php
@@ -4,7 +4,7 @@ namespace AuditCongress {
 
     class Bills extends BillTable {
 
-        use BillsGetById, BillsGetByBioguideId;
+        use GetById, GetByBioguideId;
 
         private function __construct() {
             parent::__construct("Bills", "\AuditCongress\BillsQuery");

--- a/src/php/audit.congress/objects/bills/tables/class.bills.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bills.php
@@ -4,8 +4,10 @@ namespace AuditCongress {
 
     class Bills extends BillTable {
 
+        use BillsGetById, BillsGetByBioguideId;
+
         private function __construct() {
-            parent::__construct("Bills");
+            parent::__construct("Bills", "\AuditCongress\BillsQuery");
         }
 
         private static $billsObject = null;
@@ -18,18 +20,6 @@ namespace AuditCongress {
         protected static function parseResult($rows) {
             $rows = BillRow::rowsToObjects($rows);
             return $rows;
-        }
-
-        public static function getById($billId) {
-            self::enforceCache();
-            $bill = BillsQuery::getById($billId);
-            return self::returnFirst(self::parseResult($bill));
-        }
-
-        public static function getBySponsorId($bioguideId) {
-            self::enforceCache();
-            $bills = BillsQuery::getByBioguideId($bioguideId);
-            return self::parseResult($bills);
         }
 
         public static function getByFilter($congress = null, $type = null, $number = null, $title = null, $sort = ["updated"]) {

--- a/src/php/audit.congress/objects/bills/tables/class.bills.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bills.php
@@ -7,7 +7,7 @@ namespace AuditCongress {
         use GetById, GetByBioguideId;
 
         private function __construct() {
-            parent::__construct("Bills", "\AuditCongress\BillsQuery");
+            parent::__construct("Bills", "BillsQuery", "BillRow");
         }
 
         private static $billsObject = null;
@@ -15,11 +15,6 @@ namespace AuditCongress {
             if (self::$billsObject == null) 
                 self::$billsObject = new Bills();
             return self::$billsObject;
-        }
-
-        protected static function parseResult($rows) {
-            $rows = BillRow::rowsToObjects($rows);
-            return $rows;
         }
 
         public static function getByFilter($congress = null, $type = null, $number = null, $title = null, $sort = ["updated"]) {

--- a/src/php/audit.congress/objects/class.audit.congress.query.php
+++ b/src/php/audit.congress/objects/class.audit.congress.query.php
@@ -13,6 +13,8 @@ namespace AuditCongress {
             return $theQuery;
         }
 
+        protected function applyDefaultOrder() { }
+
         protected function applyPagination() {
             $pagination = \API\Runner::getPagination();
             $this->setLimit($pagination->pageSize());

--- a/src/php/audit.congress/objects/class.audit.congress.query.php
+++ b/src/php/audit.congress/objects/class.audit.congress.query.php
@@ -30,6 +30,15 @@ namespace AuditCongress {
             return $query->selectFromDB()->fetchAllAssoc();
         }
     }
+
+    trait GetByIdQuery {
+        public static function getById($id) {
+            $query = self::getWithSearchSelect("id", "=", $id);
+            $query->applyDefaultOrder();
+            $query->applyPagination();
+            return $query->selectFromDB()->fetchAllAssoc();
+        }
+    }
 }
 
 ?>

--- a/src/php/audit.congress/objects/class.audit.congress.query.php
+++ b/src/php/audit.congress/objects/class.audit.congress.query.php
@@ -21,6 +21,15 @@ namespace AuditCongress {
             $this->setOffset($pagination->offset());
         }
     }
+
+    trait GetByBioguideIdQuery {
+        public static function getByBioguideId($bioguideId) {
+            $query = self::getWithSearchSelect("bioguideId", "=", $bioguideId);
+            $query->applyDefaultOrder();
+            $query->applyPagination();
+            return $query->selectFromDB()->fetchAllAssoc();
+        }
+    }
 }
 
 ?>

--- a/src/php/audit.congress/objects/class.audit.congress.query.php
+++ b/src/php/audit.congress/objects/class.audit.congress.query.php
@@ -13,7 +13,7 @@ namespace AuditCongress {
             return $theQuery;
         }
 
-        protected function applyDefaultOrder() { }
+        protected abstract function applyDefaultOrder();
 
         protected function applyPagination() {
             $pagination = \API\Runner::getPagination();

--- a/src/php/audit.congress/objects/class.audit.congress.table.cache.tracker.php
+++ b/src/php/audit.congress/objects/class.audit.congress.table.cache.tracker.php
@@ -37,8 +37,6 @@ namespace AuditCongress {
         }
 
         public abstract function updateCache();
-
-        public static abstract function getInstance();
     }
 }
 

--- a/src/php/audit.congress/objects/class.audit.congress.table.cache.tracker.php
+++ b/src/php/audit.congress/objects/class.audit.congress.table.cache.tracker.php
@@ -5,8 +5,8 @@ namespace AuditCongress {
         protected ?\Cache\Tracker $cacheTracker = null;
         protected $cacheIsValid = null;
         
-        protected function __construct($tableName, $queryClassName = null, $cacheName, $cacheTimeout = 5) {
-            parent::__construct($tableName, $queryClassName);
+        protected function __construct($tableName, $queryClassName = null, $rowClassName = null, $cacheName, $cacheTimeout = 5) {
+            parent::__construct($tableName, $queryClassName, $rowClassName);
             $this->cacheTracker = \Cache\Config::getTracker($cacheName);
             $this->cacheTracker->setTimeout($cacheTimeout);
         }

--- a/src/php/audit.congress/objects/class.audit.congress.table.cache.tracker.php
+++ b/src/php/audit.congress/objects/class.audit.congress.table.cache.tracker.php
@@ -3,6 +3,8 @@
 namespace AuditCongress {
     abstract class CacheTrackedTable extends AuditCongressTable{
         protected ?\Cache\Tracker $cacheTracker = null;
+        protected $cacheIsValid = null;
+        
         protected function __construct($tableName, $cacheName, $cacheTimeout = 5) {
             parent::__construct($tableName);
             $this->cacheTracker = \Cache\Config::getTracker($cacheName);
@@ -19,13 +21,10 @@ namespace AuditCongress {
                     $this->cacheIsValid = $this->cacheTracker->waitForUpdate();
                 } 
                 //Otherwise just check if the cache is out of date
-                else {
-                    $this->cacheIsValid = !$this->cacheTracker->isOutOfDate();
-                }
+                else $this->cacheIsValid = !$this->cacheTracker->isOutOfDate();
             }
             return $this->cacheIsValid;
         }
-
 
         /*
             @throws \Cache\WaitingException
@@ -34,7 +33,6 @@ namespace AuditCongress {
             //Fetch this tables instance
             $tableObj = static::getInstance();
             //If the cache is reported to be invalid (out of date) update it
-
             if (!$tableObj->cacheIsValid()) $tableObj->updateCache();
         }
 

--- a/src/php/audit.congress/objects/class.audit.congress.table.cache.tracker.php
+++ b/src/php/audit.congress/objects/class.audit.congress.table.cache.tracker.php
@@ -5,8 +5,8 @@ namespace AuditCongress {
         protected ?\Cache\Tracker $cacheTracker = null;
         protected $cacheIsValid = null;
         
-        protected function __construct($tableName, $cacheName, $cacheTimeout = 5) {
-            parent::__construct($tableName);
+        protected function __construct($tableName, $queryClassName = null, $cacheName, $cacheTimeout = 5) {
+            parent::__construct($tableName, $queryClassName);
             $this->cacheTracker = \Cache\Config::getTracker($cacheName);
             $this->cacheTracker->setTimeout($cacheTimeout);
         }

--- a/src/php/audit.congress/objects/class.audit.congress.table.cache.tracker.php
+++ b/src/php/audit.congress/objects/class.audit.congress.table.cache.tracker.php
@@ -5,8 +5,11 @@ namespace AuditCongress {
         protected ?\Cache\Tracker $cacheTracker = null;
         protected $cacheIsValid = null;
         
-        protected function __construct($tableName, $queryClassName = null, $rowClassName = null, $cacheName, $cacheTimeout = 5) {
+        protected function __construct($tableName, $queryClassName = null, $rowClassName = null) {
             parent::__construct($tableName, $queryClassName, $rowClassName);
+        }
+
+        public function setTrackedCache($cacheName, $cacheTimeout = 5) {
             $this->cacheTracker = \Cache\Config::getTracker($cacheName);
             $this->cacheTracker->setTimeout($cacheTimeout);
         }

--- a/src/php/audit.congress/objects/class.audit.congress.table.php
+++ b/src/php/audit.congress/objects/class.audit.congress.table.php
@@ -6,12 +6,19 @@ namespace AuditCongress {
     use MySqlConnector\Table;
 
     abstract class AuditCongressTable {
+        public $queryClassName = null;
         protected $name;
         private ?Table $table = null;
 
-        protected function __construct($tableName) {
+        protected function __construct($tableName, $queryClassName = null) {
             $this->name = $tableName;
+            $this->queryClassName = $queryClassName;
          }
+
+        public static function getQueryClass() {
+            $inst = static::getInstance();
+            return $inst->queryClassName;
+        }
 
         protected function getTable() { 
             if ($this->table == null) $this->table = new Table($this->name);

--- a/src/php/audit.congress/objects/class.audit.congress.table.php
+++ b/src/php/audit.congress/objects/class.audit.congress.table.php
@@ -8,7 +8,6 @@ namespace AuditCongress {
     abstract class AuditCongressTable {
         protected $name;
         private ?Table $table = null;
-        protected $cacheIsValid = null;
 
         protected function __construct($tableName) {
             $this->name = $tableName;
@@ -25,27 +24,17 @@ namespace AuditCongress {
         }
 
         public function queueInsert(SqlRow $row) {
-            $this->getTable()->queueInsert($row->getColumns(), $row->getValues());
+            $this->getTable()->queueInsert($row);
         }
         public function commitInsert() {
             $this->getTable()->commitInsert();
         }
         public function insertRow(SqlRow $row) {
-            $this->getTable()->insert($row->getColumns(), $row->getValues());
+            $this->getTable()->insert($row);
         }
 
-        public static function enforceCache() {
-            $tableObj = static::getInstance();
-            if (!$tableObj->cacheIsValid()) {
-                $tableObj->updateCache();
-            }
-        }
 
         public static abstract function getInstance();
-
-        public abstract function cacheIsValid();
-
-        public abstract function updateCache();
 
         public static function returnFirst($results) {
             if ($results == null) return null;

--- a/src/php/audit.congress/objects/class.audit.congress.table.php
+++ b/src/php/audit.congress/objects/class.audit.congress.table.php
@@ -43,6 +43,8 @@ namespace AuditCongress {
 
         public static abstract function getInstance();
 
+        protected static abstract function parseResult($resultRows);
+
         public static function returnFirst($results) {
             if ($results == null) return null;
             else if (count($results) > 0) return $results[0];

--- a/src/php/audit.congress/objects/class.audit.congress.table.php
+++ b/src/php/audit.congress/objects/class.audit.congress.table.php
@@ -7,17 +7,24 @@ namespace AuditCongress {
 
     abstract class AuditCongressTable {
         public $queryClassName = null;
+        public $rowClassName = null;
         protected $name;
         private ?Table $table = null;
 
-        protected function __construct($tableName, $queryClassName = null) {
+        protected function __construct($tableName, $queryClassName = null, $rowClassName = null) {
             $this->name = $tableName;
-            $this->queryClassName = $queryClassName;
+            $this->queryClassName = "\AuditCongress\\$queryClassName";
+            $this->rowClassName = "\AuditCongress\\$rowClassName";
          }
 
         public static function getQueryClass() {
             $inst = static::getInstance();
             return $inst->queryClassName;
+        }
+
+        public static function getRowClass() {
+            $inst = static::getInstance();
+            return $inst->rowClassName;
         }
 
         protected function getTable() { 
@@ -43,7 +50,10 @@ namespace AuditCongress {
 
         public static abstract function getInstance();
 
-        protected static abstract function parseResult($resultRows);
+        public static function parseResult($resultRows) {
+            return self::getRowClass()::rowsToObjects($resultRows);
+        }
+
 
         public static function returnFirst($results) {
             if ($results == null) return null;

--- a/src/php/audit.congress/objects/class.audit.congress.table.php
+++ b/src/php/audit.congress/objects/class.audit.congress.table.php
@@ -50,7 +50,21 @@ namespace AuditCongress {
             else if (count($results) > 0) return $results[0];
             else return $results;
         }
+    }
 
+    trait GetById {
+        public static function getById($id) {
+            self::enforceCache();
+            $items = self::getQueryClass()::getById($id);
+            return self::returnFirst(self::parseResult($items));
+        }
+    }
+    trait GetByBioguideId {
+        public static function getByBioguideId($bioguideId) {
+            self::enforceCache();
+            $items = self::getQueryClass()::getByBioguideId($bioguideId);
+            return self::parseResult($items);
+        }
     }
 }
 

--- a/src/php/audit.congress/objects/congresses/autoload.php
+++ b/src/php/audit.congress/objects/congresses/autoload.php
@@ -1,4 +1,7 @@
 <?php
+
+require_once AUDITCONGRESS_FOLDER."\objects\congresses\class.congress.table.php";
+
 require_once AUDITCONGRESS_FOLDER."\objects\congresses\\tables\class.congress.table.php";
 require_once AUDITCONGRESS_FOLDER."\objects\congresses\\tables\class.session.table.php";
 

--- a/src/php/audit.congress/objects/congresses/class.congress.table.php
+++ b/src/php/audit.congress/objects/congresses/class.congress.table.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace AuditCongress {
+
+    abstract class CongressTable extends CacheTrackedTable {
+
+        public function __construct($tableName, $queryClassName = null) {
+            parent::__construct($tableName, $queryClassName, "bulk-congress");
+        }
+
+        public function updateCache() { 
+            $this->cacheTracker->setRunning(true, "updating");
+
+            $sessionsInstance = Sessions::getInstance();
+            $congressInstance = Congresses::getInstance();
+
+            $congresses = new \CongressGov\Congresses();
+
+            $congressInstance->clearRows();
+            $sessionsInstance->clearRows();
+
+            $this->insertCongresses($congresses->congresses);
+
+            $congressInstance->commitInsert();
+            $sessionsInstance->commitInsert();
+            
+            $this->cacheIsValid = true;
+
+            $this->cacheTracker->setRunning(false, "done");
+        }
+        
+        private function insertCongresses($congresses) {
+            foreach ($congresses as $congress) {  
+                $sessions = $congress->sessions;
+                $congress = new CongressRow($congress);
+                $current = $congress->number;
+                $this->insertSessions($current, $sessions);
+                Congresses::getInstance()->queueInsert($congress);
+            }
+        }
+
+        private function insertSessions($congress, $sessions) {
+            foreach ($sessions as $session) {                
+                $session["congress"] = $congress;
+                $session = new SessionRow($session);
+                Sessions::getInstance()->queueInsert($session);
+            }
+        }
+
+        public static abstract function getInstance();
+
+        protected static abstract function parseResult($resultRows);
+    }
+}
+
+?>

--- a/src/php/audit.congress/objects/congresses/class.congress.table.php
+++ b/src/php/audit.congress/objects/congresses/class.congress.table.php
@@ -46,10 +46,6 @@ namespace AuditCongress {
                 Sessions::getInstance()->queueInsert($session);
             }
         }
-
-        public static abstract function getInstance();
-
-        protected static abstract function parseResult($resultRows);
     }
 }
 

--- a/src/php/audit.congress/objects/congresses/class.congress.table.php
+++ b/src/php/audit.congress/objects/congresses/class.congress.table.php
@@ -4,8 +4,8 @@ namespace AuditCongress {
 
     abstract class CongressTable extends CacheTrackedTable {
 
-        public function __construct($tableName, $queryClassName = null) {
-            parent::__construct($tableName, $queryClassName, "bulk-congress");
+        public function __construct($tableName, $queryClassName = null, $rowClassName = null) {
+            parent::__construct($tableName, $queryClassName, $rowClassName, "bulk-congress");
         }
 
         public function updateCache() { 

--- a/src/php/audit.congress/objects/congresses/class.congress.table.php
+++ b/src/php/audit.congress/objects/congresses/class.congress.table.php
@@ -5,7 +5,8 @@ namespace AuditCongress {
     abstract class CongressTable extends CacheTrackedTable {
 
         public function __construct($tableName, $queryClassName = null, $rowClassName = null) {
-            parent::__construct($tableName, $queryClassName, $rowClassName, "bulk-congress");
+            parent::__construct($tableName, $queryClassName, $rowClassName);
+            $this->setTrackedCache("bulk-congress");
         }
 
         public function updateCache() { 

--- a/src/php/audit.congress/objects/congresses/querys/class.congress.query.php
+++ b/src/php/audit.congress/objects/congresses/querys/class.congress.query.php
@@ -7,6 +7,10 @@ namespace AuditCongress {
             parent::__construct("Congresses");
         }
 
+        public function applyDefaultOrder() {
+            $this->setOrderBy(["number"], false);
+        }
+
         public static function getByNumber($congressNumber) {
             $congresses = new CongressQuery();
             $congresses->setSearchColumns(["number"]);

--- a/src/php/audit.congress/objects/congresses/querys/class.session.query.php
+++ b/src/php/audit.congress/objects/congresses/querys/class.session.query.php
@@ -7,6 +7,10 @@ namespace AuditCongress {
             parent::__construct("Sessions");
         }
 
+        public function applyDefaultOrder() {
+            $this->setOrderBy(["congress", "chamber", "number"], false);
+        }
+
         public static function getByCongress($congress) {
             $congresses = new SessionQuery();
             $congresses->setSearchColumns(["congress"]);

--- a/src/php/audit.congress/objects/congresses/tables/class.congress.table.php
+++ b/src/php/audit.congress/objects/congresses/tables/class.congress.table.php
@@ -2,10 +2,10 @@
 
 namespace AuditCongress {
 
-    class Congresses extends CacheTrackedTable {
+    class Congresses extends CongressTable {
         
         private function __construct() {
-            parent::__construct("Congresses", "\AuditCongress\CongressQuery", "bulk-congress");
+            parent::__construct("Congresses", "\AuditCongress\CongressQuery");
         }
 
         private static $congressTable = null;
@@ -13,37 +13,6 @@ namespace AuditCongress {
             if (self::$congressTable == null) 
                 self::$congressTable = new Congresses();
             return self::$congressTable;
-        }
-
-
-        public function updateCache() {
-            $this->cacheTracker->setRunning(true, "updating");
-            $sessionsInstance = Sessions::getInstance();
-            
-            $congresses = new \CongressGov\Congresses();
-
-            $this->clearRows();
-            $sessionsInstance->clearRows();
-
-            $this->insertCongresses($congresses->congresses);
-
-            $this->commitInsert();
-            $sessionsInstance->commitInsert();
-            
-            $this->cacheIsValid = true;
-
-            $this->cacheTracker->setRunning(false, "done");
-        }
-
-        public function insertCongresses($congresses) {
-            $sessionsInstance = Sessions::getInstance();
-            foreach ($congresses as $congress) {  
-                $sessions = $congress->sessions;
-                $congress = new CongressRow($congress);
-                $current = $congress->number;
-                $sessionsInstance->insertSessions($current, $sessions);
-                $this->queueInsert($congress);
-            }
         }
 
         protected static function parseResult($resultRows) {

--- a/src/php/audit.congress/objects/congresses/tables/class.congress.table.php
+++ b/src/php/audit.congress/objects/congresses/tables/class.congress.table.php
@@ -5,7 +5,7 @@ namespace AuditCongress {
     class Congresses extends CacheTrackedTable {
         
         private function __construct() {
-            parent::__construct("Congresses", "bulk-congress");
+            parent::__construct("Congresses", "\AuditCongress\CongressQuery", "bulk-congress");
         }
 
         private static $congressTable = null;

--- a/src/php/audit.congress/objects/congresses/tables/class.congress.table.php
+++ b/src/php/audit.congress/objects/congresses/tables/class.congress.table.php
@@ -5,7 +5,7 @@ namespace AuditCongress {
     class Congresses extends CongressTable {
         
         private function __construct() {
-            parent::__construct("Congresses", "\AuditCongress\CongressQuery");
+            parent::__construct("Congresses", "CongressQuery", "CongressRow");
         }
 
         private static $congressTable = null;
@@ -13,10 +13,6 @@ namespace AuditCongress {
             if (self::$congressTable == null) 
                 self::$congressTable = new Congresses();
             return self::$congressTable;
-        }
-
-        protected static function parseResult($resultRows) {
-            return CongressRow::rowsToObjects($resultRows);
         }
 
         private static function genericQuery($function, ...$arguments) {

--- a/src/php/audit.congress/objects/congresses/tables/class.session.table.php
+++ b/src/php/audit.congress/objects/congresses/tables/class.session.table.php
@@ -20,7 +20,7 @@ namespace AuditCongress {
         }
 
         private static function genericQuery($function, ...$arguments) {
-            Congresses::enforceCache();
+            self::enforceCache();
             $result = ("\AuditCongress\SessionQuery::$function")(...$arguments);
             return self::parseResult($result);
         }

--- a/src/php/audit.congress/objects/congresses/tables/class.session.table.php
+++ b/src/php/audit.congress/objects/congresses/tables/class.session.table.php
@@ -5,7 +5,7 @@ namespace AuditCongress {
     class Sessions extends AuditCongressTable {
         
         private function __construct() {
-            parent::__construct("Sessions");
+            parent::__construct("Sessions", "\AuditCongress\SessionQuery");
         }
 
         private static $sessionTable = null;

--- a/src/php/audit.congress/objects/congresses/tables/class.session.table.php
+++ b/src/php/audit.congress/objects/congresses/tables/class.session.table.php
@@ -2,7 +2,7 @@
 
 namespace AuditCongress {
 
-    class Sessions extends AuditCongressTable {
+    class Sessions extends CongressTable {
         
         private function __construct() {
             parent::__construct("Sessions", "\AuditCongress\SessionQuery");
@@ -13,20 +13,6 @@ namespace AuditCongress {
             if (self::$sessionTable == null) 
                 self::$sessionTable = new Sessions();
             return self::$sessionTable;
-        }
-
-        public function cacheIsValid() { 
-            return Congresses::getInstance()->cacheIsValid();
-        }
-
-        public function updateCache() { return False; }
-
-        public function insertSessions($congress, $sessions) {
-            foreach ($sessions as $session) {                
-                $session["congress"] = $congress;
-                $session = new SessionRow($session);
-                $this->queueInsert($session);
-            }
         }
 
         protected static function parseResult($resultRows) {

--- a/src/php/audit.congress/objects/congresses/tables/class.session.table.php
+++ b/src/php/audit.congress/objects/congresses/tables/class.session.table.php
@@ -5,7 +5,7 @@ namespace AuditCongress {
     class Sessions extends CongressTable {
         
         private function __construct() {
-            parent::__construct("Sessions", "\AuditCongress\SessionQuery");
+            parent::__construct("Sessions", "SessionQuery", "SessionRow");
         }
 
         private static $sessionTable = null;
@@ -13,10 +13,6 @@ namespace AuditCongress {
             if (self::$sessionTable == null) 
                 self::$sessionTable = new Sessions();
             return self::$sessionTable;
-        }
-
-        protected static function parseResult($resultRows) {
-            return SessionRow::rowsToObjects($resultRows);
         }
 
         private static function genericQuery($function, ...$arguments) {

--- a/src/php/audit.congress/objects/members/class.member.table.php
+++ b/src/php/audit.congress/objects/members/class.member.table.php
@@ -9,10 +9,6 @@ namespace AuditCongress {
         }
 
         public function updateCache() { $this->cacheTracker->runUpdateScript(); }
-        
-        public static abstract function getInstance();
-
-        protected static abstract function parseResult($resultRows);
     }
 }
 

--- a/src/php/audit.congress/objects/members/class.member.table.php
+++ b/src/php/audit.congress/objects/members/class.member.table.php
@@ -4,8 +4,8 @@ namespace AuditCongress {
 
     abstract class MemberTable extends CacheTrackedTable {
 
-        public function __construct($tableName) {
-            parent::__construct($tableName, "bulk-member");
+        public function __construct($tableName, $queryClassName = null) {
+            parent::__construct($tableName, $queryClassName, "bulk-member");
         }
 
         public function updateCache() { $this->cacheTracker->runUpdateScript(); }

--- a/src/php/audit.congress/objects/members/class.member.table.php
+++ b/src/php/audit.congress/objects/members/class.member.table.php
@@ -4,8 +4,8 @@ namespace AuditCongress {
 
     abstract class MemberTable extends CacheTrackedTable {
 
-        public function __construct($tableName, $queryClassName = null) {
-            parent::__construct($tableName, $queryClassName, "bulk-member");
+        public function __construct($tableName, $queryClassName = null, $rowClassName = null) {
+            parent::__construct($tableName, $queryClassName, $rowClassName, "bulk-member");
         }
 
         public function updateCache() { $this->cacheTracker->runUpdateScript(); }

--- a/src/php/audit.congress/objects/members/class.member.table.php
+++ b/src/php/audit.congress/objects/members/class.member.table.php
@@ -5,7 +5,8 @@ namespace AuditCongress {
     abstract class MemberTable extends CacheTrackedTable {
 
         public function __construct($tableName, $queryClassName = null, $rowClassName = null) {
-            parent::__construct($tableName, $queryClassName, $rowClassName, "bulk-member");
+            parent::__construct($tableName, $queryClassName, $rowClassName);
+            $this->setTrackedCache("bulk-member");
         }
 
         public function updateCache() { $this->cacheTracker->runUpdateScript(); }

--- a/src/php/audit.congress/objects/members/querys/class.member.elections.query.php
+++ b/src/php/audit.congress/objects/members/querys/class.member.elections.query.php
@@ -7,6 +7,10 @@ namespace AuditCongress {
             parent::__construct("MemberElections");
         }
 
+        public function applyDefaultOrder() {
+            $this->setOrderBy(["fecId", "bioguideId"], false);
+        }
+
         public static function getByBioguideId($bioguideId) {
             $terms = new MemberElectionsQuery();
             $terms->setSearchColumns(["bioguideId"]);

--- a/src/php/audit.congress/objects/members/querys/class.member.elections.query.php
+++ b/src/php/audit.congress/objects/members/querys/class.member.elections.query.php
@@ -3,19 +3,14 @@
 namespace AuditCongress {
 
     class MemberElectionsQuery extends AuditCongressQuery {
+        use GetByBioguideIdQuery;
+
         public function __construct() {
             parent::__construct("MemberElections");
         }
 
         public function applyDefaultOrder() {
             $this->setOrderBy(["fecId", "bioguideId"], false);
-        }
-
-        public static function getByBioguideId($bioguideId) {
-            $terms = new MemberElectionsQuery();
-            $terms->setSearchColumns(["bioguideId"]);
-            $terms->setSearchValues([$bioguideId]);
-            return $terms->selectFromDB()->fetchAllAssoc();
         }
 
         public static function getByFecId($fecId) {

--- a/src/php/audit.congress/objects/members/querys/class.member.offices.query.php
+++ b/src/php/audit.congress/objects/members/querys/class.member.offices.query.php
@@ -7,6 +7,10 @@ namespace AuditCongress {
             parent::__construct("MemberOffices");
         }
 
+        public function applyDefaultOrder() {
+            $this->setOrderBy(["officeId"], false);
+        }
+
         public static function getByBioguideId($bioguideId) {
             $offices = new MemberOfficesQuery();
             $offices->setSearchColumns(["bioguideId"]);

--- a/src/php/audit.congress/objects/members/querys/class.member.offices.query.php
+++ b/src/php/audit.congress/objects/members/querys/class.member.offices.query.php
@@ -3,21 +3,14 @@
 namespace AuditCongress {
 
     class MemberOfficesQuery extends AuditCongressQuery {
-        use GetByBioguideIdQuery;
+        use GetByBioguideIdQuery, GetByIdQuery;
 
         public function __construct() {
             parent::__construct("MemberOffices");
         }
 
         public function applyDefaultOrder() {
-            $this->setOrderBy(["officeId"], false);
-        }
-
-        public static function getByOfficeId($officeId) {
-            $offices = new MemberOfficesQuery();
-            $offices->setSearchColumns(["officeId"]);
-            $offices->setSearchValues([$officeId]);
-            return $offices->selectFromDB()->fetchAllAssoc();
+            $this->setOrderBy(["id"], false);
         }
     }
 }

--- a/src/php/audit.congress/objects/members/querys/class.member.offices.query.php
+++ b/src/php/audit.congress/objects/members/querys/class.member.offices.query.php
@@ -3,19 +3,14 @@
 namespace AuditCongress {
 
     class MemberOfficesQuery extends AuditCongressQuery {
+        use GetByBioguideIdQuery;
+
         public function __construct() {
             parent::__construct("MemberOffices");
         }
 
         public function applyDefaultOrder() {
             $this->setOrderBy(["officeId"], false);
-        }
-
-        public static function getByBioguideId($bioguideId) {
-            $offices = new MemberOfficesQuery();
-            $offices->setSearchColumns(["bioguideId"]);
-            $offices->setSearchValues([$bioguideId]);
-            return $offices->selectFromDB()->fetchAllAssoc();
         }
 
         public static function getByOfficeId($officeId) {

--- a/src/php/audit.congress/objects/members/querys/class.member.socials.query.php
+++ b/src/php/audit.congress/objects/members/querys/class.member.socials.query.php
@@ -3,19 +3,14 @@
 namespace AuditCongress {
     
     class MemberSocialsQuery extends AuditCongressQuery {
+        use GetByBioguideIdQuery;
+
         public function __construct() {
             parent::__construct("MemberSocials");
         }
 
         public function applyDefaultOrder() {
             $this->setOrderBy(["bioguideId"], false);
-        }
-
-        public static function getByBioguideId($bioguideId) {
-            $socials = new MemberSocialsQuery();
-            $socials->setSearchColumns(["bioguideId"]);
-            $socials->setSearchValues([$bioguideId]);
-            return $socials->selectFromDB()->fetchAllAssoc();
         }
     }
 }

--- a/src/php/audit.congress/objects/members/querys/class.member.socials.query.php
+++ b/src/php/audit.congress/objects/members/querys/class.member.socials.query.php
@@ -7,6 +7,10 @@ namespace AuditCongress {
             parent::__construct("MemberSocials");
         }
 
+        public function applyDefaultOrder() {
+            $this->setOrderBy(["bioguideId"], false);
+        }
+
         public static function getByBioguideId($bioguideId) {
             $socials = new MemberSocialsQuery();
             $socials->setSearchColumns(["bioguideId"]);

--- a/src/php/audit.congress/objects/members/querys/class.member.terms.query.php
+++ b/src/php/audit.congress/objects/members/querys/class.member.terms.query.php
@@ -7,6 +7,10 @@ namespace AuditCongress {
             parent::__construct("MemberTerms");
         }
 
+        public function applyDefaultOrder() {
+            $this->setOrderBy(["start"], false);
+        }
+
         public static function getByBioguideId($bioguideId) {
             $terms = new MemberTermsQuery();
             $terms->setSearchColumns(["bioguideId"]);

--- a/src/php/audit.congress/objects/members/querys/class.member.terms.query.php
+++ b/src/php/audit.congress/objects/members/querys/class.member.terms.query.php
@@ -3,19 +3,14 @@
 namespace AuditCongress {
 
     class MemberTermsQuery extends AuditCongressQuery {
+        use GetByBioguideIdQuery;
+        
         public function __construct() {
             parent::__construct("MemberTerms");
         }
 
         public function applyDefaultOrder() {
             $this->setOrderBy(["start"], false);
-        }
-
-        public static function getByBioguideId($bioguideId) {
-            $terms = new MemberTermsQuery();
-            $terms->setSearchColumns(["bioguideId"]);
-            $terms->setSearchValues([$bioguideId]);
-            return $terms->selectFromDB()->fetchAllAssoc();
         }
 
         private static function getSingleTermByBioguideId($bioguideId) {

--- a/src/php/audit.congress/objects/members/querys/class.members.query.php
+++ b/src/php/audit.congress/objects/members/querys/class.members.query.php
@@ -7,6 +7,10 @@ namespace AuditCongress {
             parent::__construct("Members");
         }
 
+        public function applyDefaultOrder() {
+            $this->setOrderBy(["bioguideId", "start"], false);
+        }
+
         public static function getBioguideToThomasIdMapping() {
             $members = new MembersQuery();
             $members->setSelectColumns(["bioguideId", "thomasId"]);

--- a/src/php/audit.congress/objects/members/querys/class.members.query.php
+++ b/src/php/audit.congress/objects/members/querys/class.members.query.php
@@ -3,24 +3,19 @@
 namespace AuditCongress {
 
     class MembersQuery extends AuditCongressQuery {
+        use GetByBioguideIdQuery;
+        
         public function __construct() {
             parent::__construct("Members");
         }
 
         public function applyDefaultOrder() {
-            $this->setOrderBy(["bioguideId", "start"], false);
+            $this->setOrderBy(["bioguideId"], false);
         }
 
         public static function getBioguideToThomasIdMapping() {
             $members = new MembersQuery();
             $members->setSelectColumns(["bioguideId", "thomasId"]);
-            return $members->selectFromDB()->fetchAllAssoc();
-        }
-
-        public static function getByBioguideId($bioguideId, $isCurrent = null) {
-            $members = new MembersQuery();
-            $members->setSearchColumns(["bioguideId", "isCurrent"]);
-            $members->setSearchValues([$bioguideId, $isCurrent]);
             return $members->selectFromDB()->fetchAllAssoc();
         }
 

--- a/src/php/audit.congress/objects/members/rows/class.member.offices.row.php
+++ b/src/php/audit.congress/objects/members/rows/class.member.offices.row.php
@@ -4,18 +4,18 @@ namespace AuditCongress {
 
     class MemberOfficesRow extends \MySqlConnector\SqlRow {
         public
-            $bioguideId,$officeId,
+            $bioguideId,$id,
             $address,$suite,$building,$city,$state,$zip,
             $latitude,$longitude,$phone,$fax;
 
         public function getColumns() {
-            return ["bioguideId","officeId","address","suite",
+            return ["bioguideId","id","address","suite",
                     "building","city","state","zip","latitude",
                     "longitude","phone","fax"];
         }
 
         public function getValues() {
-            return [$this->bioguideId,$this->officeId,$this->address,
+            return [$this->bioguideId,$this->id,$this->address,
             $this->suite,$this->building,$this->city,$this->state,
             $this->zip,$this->latitude,$this->longitude,$this->phone,$this->fax];
         }

--- a/src/php/audit.congress/objects/members/tables/class.member.elections.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.elections.php
@@ -5,7 +5,7 @@ namespace AuditCongress {
     class MemberElections extends MemberTable {
         
         private function __construct() {
-            parent::__construct("MemberElections");
+            parent::__construct("MemberElections", "\AuditCongress\MemberElectionsQuery");
         }
 
         private static $memberTermsTable = null;

--- a/src/php/audit.congress/objects/members/tables/class.member.elections.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.elections.php
@@ -3,7 +3,8 @@
 namespace AuditCongress {
 
     class MemberElections extends MemberTable {
-        
+        use GetByBioguideId;
+
         private function __construct() {
             parent::__construct("MemberElections", "\AuditCongress\MemberElectionsQuery");
         }
@@ -17,12 +18,6 @@ namespace AuditCongress {
 
         protected static function parseResult($resultRows) {
             return MemberElectionRow::rowsToObjects($resultRows);
-        }
-
-        public static function getByBioguideId($bioguideId) {
-            self::enforceCache();
-            $elections = MemberElectionsQuery::getByBioguideId($bioguideId);
-            return self::parseResult($elections);
         }
 
         public static function getByFecId($fecId) {

--- a/src/php/audit.congress/objects/members/tables/class.member.elections.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.elections.php
@@ -6,7 +6,7 @@ namespace AuditCongress {
         use GetByBioguideId;
 
         private function __construct() {
-            parent::__construct("MemberElections", "\AuditCongress\MemberElectionsQuery");
+            parent::__construct("MemberElections", "MemberElectionsQuery", "MemberElectionRow");
         }
 
         private static $memberTermsTable = null;
@@ -14,10 +14,6 @@ namespace AuditCongress {
             if (self::$memberTermsTable == null) 
                 self::$memberTermsTable = new MemberElections();
             return self::$memberTermsTable;
-        }
-
-        protected static function parseResult($resultRows) {
-            return MemberElectionRow::rowsToObjects($resultRows);
         }
 
         public static function getByFecId($fecId) {

--- a/src/php/audit.congress/objects/members/tables/class.member.offices.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.offices.php
@@ -5,7 +5,7 @@ namespace AuditCongress {
     class MemberOffices extends MemberTable {
 
         private function __construct() {
-            parent::__construct("MemberOffices");
+            parent::__construct("MemberOffices", "\AuditCongress\MemberOfficesQuery");
         }
 
         private static $memberOfficesTable = null;

--- a/src/php/audit.congress/objects/members/tables/class.member.offices.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.offices.php
@@ -3,7 +3,7 @@
 namespace AuditCongress {
 
     class MemberOffices extends MemberTable {
-
+        use GetByBioguideId, GetById;
         private function __construct() {
             parent::__construct("MemberOffices", "\AuditCongress\MemberOfficesQuery");
         }
@@ -17,17 +17,6 @@ namespace AuditCongress {
 
         protected static function parseResult($resultRows) {
             return MemberOfficesRow::rowsToObjects($resultRows);
-        }
-
-        public static function getByBioguideId($bioguideId) {
-            $offices = MemberOfficesQuery::getByBioguideId($bioguideId);
-            return self::parseResult($offices);
-        }
-
-        public static function getByOfficeId($officeId) {
-            self::enforceCache();
-            $offices = MemberOfficesQuery::getByOfficeId($officeId);
-            return self::parseResult($offices);
         }
     }
 }

--- a/src/php/audit.congress/objects/members/tables/class.member.offices.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.offices.php
@@ -5,7 +5,7 @@ namespace AuditCongress {
     class MemberOffices extends MemberTable {
         use GetByBioguideId, GetById;
         private function __construct() {
-            parent::__construct("MemberOffices", "\AuditCongress\MemberOfficesQuery");
+            parent::__construct("MemberOffices", "MemberOfficesQuery", "MemberOfficesRow");
         }
 
         private static $memberOfficesTable = null;
@@ -13,10 +13,6 @@ namespace AuditCongress {
             if (self::$memberOfficesTable == null) 
                 self::$memberOfficesTable = new MemberOffices();
             return self::$memberOfficesTable;
-        }
-
-        protected static function parseResult($resultRows) {
-            return MemberOfficesRow::rowsToObjects($resultRows);
         }
     }
 }

--- a/src/php/audit.congress/objects/members/tables/class.member.socials.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.socials.php
@@ -3,7 +3,8 @@
 namespace AuditCongress {
 
     class MemberSocials extends MemberTable {
-        
+        use GetByBioguideId;
+
         private function __construct() {
             parent::__construct("MemberSocials", "\AuditCongress\MemberSocialsQuery");
         }
@@ -17,12 +18,6 @@ namespace AuditCongress {
 
         protected static function parseResult($resultRows) {
             return MemberSocialsRow::rowsToObjects($resultRows);
-        }
-
-        public static function getByBioguideId($bioguideId) {
-            self::enforceCache();
-            $socials = MemberSocialsQuery::getByBioguideId($bioguideId);
-            return self::returnFirst(self::parseResult($socials));
         }
     }
 }

--- a/src/php/audit.congress/objects/members/tables/class.member.socials.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.socials.php
@@ -5,7 +5,7 @@ namespace AuditCongress {
     class MemberSocials extends MemberTable {
         
         private function __construct() {
-            parent::__construct("MemberSocials");
+            parent::__construct("MemberSocials", "\AuditCongress\MemberSocialsQuery");
         }
 
         private static $memberSocialsTable = null;

--- a/src/php/audit.congress/objects/members/tables/class.member.socials.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.socials.php
@@ -6,7 +6,7 @@ namespace AuditCongress {
         use GetByBioguideId;
 
         private function __construct() {
-            parent::__construct("MemberSocials", "\AuditCongress\MemberSocialsQuery");
+            parent::__construct("MemberSocials", "MemberSocialsQuery", "MemberSocialsRow");
         }
 
         private static $memberSocialsTable = null;
@@ -14,10 +14,6 @@ namespace AuditCongress {
             if (self::$memberSocialsTable == null) 
                 self::$memberSocialsTable = new MemberSocials();
             return self::$memberSocialsTable;
-        }
-
-        protected static function parseResult($resultRows) {
-            return MemberSocialsRow::rowsToObjects($resultRows);
         }
     }
 }

--- a/src/php/audit.congress/objects/members/tables/class.member.terms.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.terms.php
@@ -5,7 +5,7 @@ namespace AuditCongress {
     class MemberTerms extends MemberTable {
         
         private function __construct() {
-            parent::__construct("MemberTerms");
+            parent::__construct("MemberTerms", "\AuditCongress\MemberTermsQuery");
         }
 
         private static $memberTermsTable = null;

--- a/src/php/audit.congress/objects/members/tables/class.member.terms.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.terms.php
@@ -6,7 +6,7 @@ namespace AuditCongress {
         use GetByBioguideId;
 
         private function __construct() {
-            parent::__construct("MemberTerms", "\AuditCongress\MemberTermsQuery");
+            parent::__construct("MemberTerms", "MemberTermsQuery", "MemberTermRow");
         }
 
         private static $memberTermsTable = null;
@@ -14,10 +14,6 @@ namespace AuditCongress {
             if (self::$memberTermsTable == null) 
                 self::$memberTermsTable = new MemberTerms();
             return self::$memberTermsTable;
-        }
-
-        protected static function parseResult($resultRows) {
-            return MemberTermRow::rowsToObjects($resultRows);
         }
 
         public static function getLastByBioguideId($bioguideId) {

--- a/src/php/audit.congress/objects/members/tables/class.member.terms.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.terms.php
@@ -3,7 +3,8 @@
 namespace AuditCongress {
     
     class MemberTerms extends MemberTable {
-        
+        use GetByBioguideId;
+
         private function __construct() {
             parent::__construct("MemberTerms", "\AuditCongress\MemberTermsQuery");
         }
@@ -17,12 +18,6 @@ namespace AuditCongress {
 
         protected static function parseResult($resultRows) {
             return MemberTermRow::rowsToObjects($resultRows);
-        }
-
-        public static function getByBioguideId($bioguideId) {
-            self::enforceCache();
-            $terms = MemberTermsQuery::getByBioguideId($bioguideId);
-            return self::parseResult($terms);
         }
 
         public static function getLastByBioguideId($bioguideId) {

--- a/src/php/audit.congress/objects/members/tables/class.members.php
+++ b/src/php/audit.congress/objects/members/tables/class.members.php
@@ -64,9 +64,9 @@ namespace AuditCongress {
             return $mapping;
         }
 
-        public static function getByBioguideId($bioguideId, $isCurrent = null) {
+        public static function getByBioguideId($bioguideId) {
             self::enforceCache();
-            $members = MembersQuery::getByBioguideId($bioguideId, $isCurrent);
+            $members = MembersQuery::getByBioguideId($bioguideId);
             return self::returnFirst(self::parseResult($members));
         }
 

--- a/src/php/audit.congress/objects/members/tables/class.members.php
+++ b/src/php/audit.congress/objects/members/tables/class.members.php
@@ -3,6 +3,7 @@
 namespace AuditCongress {
 
     class Members extends MemberTable {
+        use GetByBioguideId;
 
         private function __construct() {
             parent::__construct("Members", "\AuditCongress\MembersQuery");
@@ -62,12 +63,6 @@ namespace AuditCongress {
                 if (strlen($member["thomasId"]) > 0 && strlen($member["bioguideId"]) > 0)
                     $mapping[$member["thomasId"]] = $member["bioguideId"];
             return $mapping;
-        }
-
-        public static function getByBioguideId($bioguideId) {
-            self::enforceCache();
-            $members = MembersQuery::getByBioguideId($bioguideId);
-            return self::returnFirst(self::parseResult($members));
         }
 
         public static function getByName($firstName = null, $lastName = null, $isCurrent = null) {

--- a/src/php/audit.congress/objects/members/tables/class.members.php
+++ b/src/php/audit.congress/objects/members/tables/class.members.php
@@ -5,7 +5,7 @@ namespace AuditCongress {
     class Members extends MemberTable {
 
         private function __construct() {
-            parent::__construct("Members");
+            parent::__construct("Members", "\AuditCongress\MembersQuery");
         }
 
         private static $membersObject = null;

--- a/src/php/audit.congress/objects/members/tables/class.members.php
+++ b/src/php/audit.congress/objects/members/tables/class.members.php
@@ -6,7 +6,7 @@ namespace AuditCongress {
         use GetByBioguideId;
 
         private function __construct() {
-            parent::__construct("Members", "\AuditCongress\MembersQuery");
+            parent::__construct("Members", "MembersQuery", "MemberRow");
         }
 
         private static $membersObject = null;
@@ -24,11 +24,13 @@ namespace AuditCongress {
             try {
                 $congressMember = new \CongressGov\Member($bioguideId);
                 $depiction = $congressMember->depiction;
-            } catch (ApiException $e) { }
+            } catch (ApiException $e) { 
+                //var_dump("Exception $e");
+            }
 
             if (is_array($depiction)) {
-                $imageUrl = in_array("imageUrl", $depiction) ? $depiction["imageUrl"] : 'false';
-                $imageAttribution = in_array("attribution", $depiction) ? $depiction["attribution"] : 'false';
+                $imageUrl = array_key_exists("imageUrl", $depiction) ? $depiction["imageUrl"] : 'false';
+                $imageAttribution = array_key_exists("attribution", $depiction) ? $depiction["attribution"] : 'false';
             }
 
             return array("imageUrl" => $imageUrl, "imageAttribution" => $imageAttribution);
@@ -50,9 +52,8 @@ namespace AuditCongress {
             return $members;
         }
 
-        protected static function parseResult($rows) {
-            $rows = self::ensureMembersHaveImage($rows);
-            return $rows;
+        public static function parseResult($rows) {
+            return self::ensureMembersHaveImage($rows);
         }
 
         public static function getBioguideToThomasIdMapping() {

--- a/src/php/mysql.connector/abstract.sql.object.php
+++ b/src/php/mysql.connector/abstract.sql.object.php
@@ -15,33 +15,19 @@ namespace MySqlConnector {
             $this->setBooleanCondition($booleanOperator);
         }
 
-        public function countInDB() {
-            return $this->table->count($this->whereCondition());
-        }
+        public function getAsRow() { return SqlRow::fromColsAndVals($this->getColumns(), $this->getValues()); }
 
-        public function selectFromDB() { 
-            return $this->table->selectObject($this);
-            /*return $this->table->select($this->getSelectColumns(), $this->whereCondition(), $this->getJoin(), 
-                            $this->getGroupBy(), $this->getOrderBy(), $this->getLimit(), $this->getOffset());*/
-        }
+        public function countInDB() { return $this->table->count($this->whereCondition()); }
 
-        public function deleteFromDb() { 
-            return $this->table->delete($this->whereCondition());
-        }
+        public function selectFromDB() { return $this->table->selectObject($this); }
 
-        public function insertIntoDB() { 
-            return $this->table->insert($this->getColumns(), $this->getValues());
+        public function deleteFromDb() { return $this->table->delete($this->whereCondition()); }
 
-        }
+        public function insertIntoDB() { return $this->table->insert($this->getAsRow()); }
 
-        public function updateInDb() { 
-            return $this->table->update($this->getColumns(), $this->getValues(), 
-                                        $this->whereCondition());
-        }
+        public function updateInDb() { return $this->table->update($this->getAsRow(), $this->whereCondition()); }
 
-        public static function throwSqlObjectError($message) {
-            throw new SqlException("SqlObject: $message");
-        }
+        public static function throwSqlObjectError($message) { throw new SqlException("SqlObject: $message"); }
 
 
 

--- a/src/php/mysql.connector/structures/mysql.row.php
+++ b/src/php/mysql.connector/structures/mysql.row.php
@@ -1,27 +1,41 @@
 <?php
 
 namespace MySqlConnector {
-    abstract class SqlRow {
-        public function __construct($rowAssocArray = null) {
-            $this->setFieldsFromObject($rowAssocArray);    
+    class SqlRow {
+        protected
+            $columns = [],
+            $values = [];
+        public function __construct($rowAssocArray = null, $setAsArrays = false) {
+            if ($setAsArrays) $this->setArraysFromAssoc($rowAssocArray);
+            else $this->setFieldsFromAssoc($rowAssocArray);    
         }
 
-        public abstract function getColumns();
-        public abstract function getValues();
-        function setFieldsFromObject($obj, $keyMustExist = true) {
-            if ($obj == null) return;
+        public static function fromColsAndVals($columns, $values) {
+            $rowAssoc = array();
+            for ($i = 0;$i < count($columns);$i++) $rowAssoc[$columns[$i]] = $values[$i];
+            return new static($rowAssoc, true);
+        }
+
+        public function getColumns() { return $this->columns; }
+        public function getValues() { return $this->values; }
+
+        private function setFieldsFromAssoc($obj, $keyMustExist = true) {
             foreach ($obj as $key=>$value)
                 if (($keyMustExist && property_exists($this, $key)) || !$keyMustExist) 
                     $this->{$key} = $value;
         }
 
+        private function setArraysFromAssoc($obj) {
+            foreach ($obj as $key=>$value) {
+                array_push($this->columns, $key);
+                array_push($this->values, $value);
+            }
+        }
+
         
         public static function rowsToObjects($rows) {
             $rowObjects = array();
-            $objectType = static::class;
-            foreach ($rows as $row) {
-                array_push($rowObjects, new $objectType($row));
-            }
+            foreach ($rows as $row) array_push($rowObjects, new static($row));
             return $rowObjects;
         }
     }

--- a/src/py/members/bulk-member-pull.py
+++ b/src/py/members/bulk-member-pull.py
@@ -29,7 +29,7 @@ TERM_COLUMNS = ["bioguideId", "type", "start", "end", "state", "district", "part
 ELECTION_COLUMNS = ["fecId", "bioguideId"]
 SOCIAL_COLUMNS = ["bioguideId", "twitter", "twitterId", "facebook", "facebookId", "youtube", "youtubeId", 
                   "instagram", "instagramId"]
-OFFICES_COLUMNS = ["officeId", "bioguideId", "address", "suite", "building", "city", "state", "zip", 
+OFFICES_COLUMNS = ["id", "bioguideId", "address", "suite", "building", "city", "state", "zip", 
                    "latitude", "longitude", "phone", "fax"]
 
 COMMITTEE_COLUMNS = ["thomasId", "parentId", "type", "name", "wikipedia", "jurisdiction", "jurisdiction_source", 


### PR DESCRIPTION
1. Clean up in `MySqlConnector` to use `SqlRow`s more (which simplifies certain logic)
2. Convert all classes implementing `AuditCongressTable`s to use traits & be more generalized
3. Shift some cache logic into `CacheTrackedTable`s only
4. Shift other logic all the way out into `AuditCongressTable`s to remove identical functions
5. Overall reducing duplication present in the table interface.

closes #73 