### PR TITLE
Refactor get instance uses - remove where it makes sense

### DIFF
--- a/src/php/api/base.classes/class.route.group.php
+++ b/src/php/api/base.classes/class.route.group.php
@@ -15,9 +15,6 @@ namespace API {
 
         public function name() { return $this->baseRoute; }
 
-        //All RouteGroups exist as singletons
-        public abstract static function getInstance();
-
         //Fetch all route names used by this group
         public function fetchRouteClassNames() {
             return \Util\Classes::thatExtend($this->routeBaseClass);

--- a/src/php/api/class.runner.php
+++ b/src/php/api/class.runner.php
@@ -68,9 +68,9 @@ namespace API {
             //Get all classes that extend RouteGroups
             $routeGroups = \Util\Classes::thatExtend("\API\RouteGroup");
             foreach ($routeGroups as $group) {
-                $instance = ("$group::getInstance")();
-                if ($instance->isRoute($route)) {
-                    self::runRouteGroup($instance);
+                $group = new $group();
+                if ($group->isRoute($route)) {
+                    self::runRouteGroup($group);
                     return;
                 }
             }

--- a/src/php/api/routes/bills/class.bills.php
+++ b/src/php/api/routes/bills/class.bills.php
@@ -2,14 +2,8 @@
 
 namespace API {
     class Bills extends RouteGroup {
-        private function __construct() {
+        public function __construct() {
             parent::__construct("bills", "\API\BillsRoute");
-        }
-
-        private static $billInstance = null;
-        public static function getInstance() {
-            if (self::$billInstance == null) self::$billInstance = new \API\Bills();
-            return self::$billInstance;
         }
     }
 

--- a/src/php/api/routes/congress/class.congress.php
+++ b/src/php/api/routes/congress/class.congress.php
@@ -2,14 +2,8 @@
 
 namespace API {
     class Congress extends RouteGroup {
-        private function __construct() {
+        public function __construct() {
             parent::__construct("congress", "\API\CongressRoute");
-        }
-
-        private static $congressInstance = null;
-        public static function getInstance() {
-            if (self::$congressInstance == null) self::$congressInstance = new \API\Congress();
-            return self::$congressInstance;
         }
     }
 

--- a/src/php/api/routes/cosponsors/class.cosponsors.php
+++ b/src/php/api/routes/cosponsors/class.cosponsors.php
@@ -2,14 +2,8 @@
 
 namespace API {
     class Cosponsors extends RouteGroup {
-        private function __construct() {
+        public function __construct() {
             parent::__construct("cosponsors", "\API\CosponsorsRoute");
-        }
-
-        private static $cosponsorsInstance = null;
-        public static function getInstance() {
-            if (self::$cosponsorsInstance == null) self::$cosponsorsInstance = new \API\Cosponsors();
-            return self::$cosponsorsInstance;
         }
     }
 

--- a/src/php/api/routes/elections/class.elections.php
+++ b/src/php/api/routes/elections/class.elections.php
@@ -2,14 +2,8 @@
 
 namespace API {
     class Elections extends RouteGroup {
-        private function __construct() {
+        public function __construct() {
             parent::__construct("elections", "\API\ElectionsRoute");
-        }
-
-        private static $memberInstance = null;
-        public static function getInstance() {
-            if (self::$memberInstance == null) self::$memberInstance = new \API\Elections();
-            return self::$memberInstance;
         }
     }
 

--- a/src/php/api/routes/member/class.member.php
+++ b/src/php/api/routes/member/class.member.php
@@ -2,14 +2,8 @@
 
 namespace API {
     class Member extends RouteGroup {
-        private function __construct() {
+        public function __construct() {
             parent::__construct("members", "\API\MemberRoute");
-        }
-
-        private static $memberInstance = null;
-        public static function getInstance() {
-            if (self::$memberInstance == null) self::$memberInstance = new \API\Member();
-            return self::$memberInstance;
         }
     }
 

--- a/src/php/api/routes/offices/class.offices.php
+++ b/src/php/api/routes/offices/class.offices.php
@@ -2,14 +2,8 @@
 
 namespace API {
     class Offices extends RouteGroup {
-        private function __construct() {
+        public function __construct() {
             parent::__construct("offices", "\API\OfficesRoute");
-        }
-
-        private static $memberInstance = null;
-        public static function getInstance() {
-            if (self::$memberInstance == null) self::$memberInstance = new \API\Offices();
-            return self::$memberInstance;
         }
     }
 

--- a/src/php/api/routes/session/class.session.php
+++ b/src/php/api/routes/session/class.session.php
@@ -2,14 +2,8 @@
 
 namespace API {
     class Session extends RouteGroup {
-        private function __construct() {
+        public function __construct() {
             parent::__construct("session", "\API\SessionRoute");
-        }
-
-        private static $sessionInstance = null;
-        public static function getInstance() {
-            if (self::$sessionInstance == null) self::$sessionInstance = new \API\Session();
-            return self::$sessionInstance;
         }
     }
 

--- a/src/php/api/routes/socials/class.socials.php
+++ b/src/php/api/routes/socials/class.socials.php
@@ -2,14 +2,8 @@
 
 namespace API {
     class Socials extends RouteGroup {
-        private function __construct() {
+        public function __construct() {
             parent::__construct("socials", "\API\SocialsRoute");
-        }
-
-        private static $memberInstance = null;
-        public static function getInstance() {
-            if (self::$memberInstance == null) self::$memberInstance = new \API\Socials();
-            return self::$memberInstance;
         }
     }
 

--- a/src/php/api/routes/subjects/class.subjects.php
+++ b/src/php/api/routes/subjects/class.subjects.php
@@ -2,14 +2,8 @@
 
 namespace API {
     class Subjects extends RouteGroup {
-        private function __construct() {
+        public function __construct() {
             parent::__construct("subjects", "\API\SubjectsRoute");
-        }
-
-        private static $subjectsInstance = null;
-        public static function getInstance() {
-            if (self::$subjectsInstance == null) self::$subjectsInstance = new \API\Subjects();
-            return self::$subjectsInstance;
         }
     }
 

--- a/src/php/api/routes/system/class.bioguideToThomas.php
+++ b/src/php/api/routes/system/class.bioguideToThomas.php
@@ -2,14 +2,8 @@
 
 namespace API {
     class BioguideToThomas extends RouteGroup {
-        private function __construct() {
+        public function __construct() {
             parent::__construct("bioguideToThomas", "\API\BioguideToThomasRoute");
-        }
-
-        private static $bioguideToThomasInstance = null;
-        public static function getInstance() {
-            if (self::$bioguideToThomasInstance == null) self::$bioguideToThomasInstance = new \API\BioguideToThomas();
-            return self::$bioguideToThomasInstance;
         }
     }
 

--- a/src/php/api/routes/system/class.validateSchema.php
+++ b/src/php/api/routes/system/class.validateSchema.php
@@ -2,14 +2,8 @@
 
 namespace API {
     class ValidateSchema extends RouteGroup {
-        private function __construct() {
+        public function __construct() {
             parent::__construct("validateSchema", "\API\ValidateSchemaRoute");
-        }
-
-        private static $validateInstance = null;
-        public static function getInstance() {
-            if (self::$validateInstance == null) self::$validateInstance = new \API\ValidateSchema();
-            return self::$validateInstance;
         }
     }
 

--- a/src/php/api/routes/terms/class.terms.php
+++ b/src/php/api/routes/terms/class.terms.php
@@ -2,14 +2,8 @@
 
 namespace API {
     class Terms extends RouteGroup {
-        private function __construct() {
+        public function __construct() {
             parent::__construct("terms", "\API\TermsRoute");
-        }
-
-        private static $memberInstance = null;
-        public static function getInstance() {
-            if (self::$memberInstance == null) self::$memberInstance = new \API\Terms();
-            return self::$memberInstance;
         }
     }
 

--- a/src/php/api/routes/titles/class.titles.php
+++ b/src/php/api/routes/titles/class.titles.php
@@ -2,14 +2,8 @@
 
 namespace API {
     class Titles extends RouteGroup {
-        private function __construct() {
+        public function __construct() {
             parent::__construct("titles", "\API\TitlesRoute");
-        }
-
-        private static $cosponsorsInstance = null;
-        public static function getInstance() {
-            if (self::$cosponsorsInstance == null) self::$cosponsorsInstance = new \API\Titles();
-            return self::$cosponsorsInstance;
         }
     }
 

--- a/src/php/audit.congress/objects/bills/tables/class.bill.cosponsors.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bill.cosponsors.php
@@ -4,17 +4,10 @@ namespace AuditCongress {
 
     class BillCosponsors extends BillTable {
 
-        use GetById, BillsGetByBillId, GetByBioguideId;
+        use \Util\GetInstance, GetById, BillsGetByBillId, GetByBioguideId;
 
         private function __construct() {
             parent::__construct("BillCosponsors", "BillCosponsorsQuery", "BillCosponsorRow");
-        }
-
-        private static $billsObject = null;
-        public static function getInstance() {
-            if (self::$billsObject == null) 
-                self::$billsObject = new BillCosponsors();
-            return self::$billsObject;
         }
 
         public static function getByFilter($congress = null, $type = null, $number = null, $bioguideId = null, $sort = ["sponsoredAt"]) {

--- a/src/php/audit.congress/objects/bills/tables/class.bill.subjects.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bill.subjects.php
@@ -4,17 +4,10 @@ namespace AuditCongress {
 
     class BillSubjects extends BillTable {
 
-        use GetById, BillsGetByBillId;
+        use \Util\GetInstance, GetById, BillsGetByBillId;
 
         private function __construct() {
             parent::__construct("BillSubjects", "BillSubjectsQuery", "BillSubjectRow");
-        }
-
-        private static $billsObject = null;
-        public static function getInstance() {
-            if (self::$billsObject == null) 
-                self::$billsObject = new BillSubjects();
-            return self::$billsObject;
         }
 
         public static function getByFilter($congress = null, $type = null, $number = null, $subject = null) {

--- a/src/php/audit.congress/objects/bills/tables/class.bill.titles.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bill.titles.php
@@ -4,17 +4,10 @@ namespace AuditCongress {
 
     class BillTitles extends BillTable {
 
-        use GetById, BillsGetByBillId;
+        use \Util\GetInstance, GetById, BillsGetByBillId;
 
         private function __construct() {
             parent::__construct("BillTitles", "BillTitlesQuery", "BillTitleRow");
-        }
-
-        private static $billsObject = null;
-        public static function getInstance() {
-            if (self::$billsObject == null) 
-                self::$billsObject = new BillTitles();
-            return self::$billsObject;
         }
 
         public static function getByFilter($congress = null, $type = null, $number = null, $title = null) {

--- a/src/php/audit.congress/objects/bills/tables/class.bills.php
+++ b/src/php/audit.congress/objects/bills/tables/class.bills.php
@@ -4,17 +4,10 @@ namespace AuditCongress {
 
     class Bills extends BillTable {
 
-        use GetById, GetByBioguideId;
+        use \Util\GetInstance, GetById, GetByBioguideId;
 
         private function __construct() {
             parent::__construct("Bills", "BillsQuery", "BillRow");
-        }
-
-        private static $billsObject = null;
-        public static function getInstance() {
-            if (self::$billsObject == null) 
-                self::$billsObject = new Bills();
-            return self::$billsObject;
         }
 
         public static function getByFilter($congress = null, $type = null, $number = null, $title = null, $sort = ["updated"]) {

--- a/src/php/audit.congress/objects/class.audit.congress.table.php
+++ b/src/php/audit.congress/objects/class.audit.congress.table.php
@@ -47,7 +47,7 @@ namespace AuditCongress {
             $this->getTable()->insert($row);
         }
 
-
+        //All Tables are singletons. Use \Util\GetInstance on each class.
         public static abstract function getInstance();
 
         public static function parseResult($resultRows) {

--- a/src/php/audit.congress/objects/congresses/tables/class.congress.table.php
+++ b/src/php/audit.congress/objects/congresses/tables/class.congress.table.php
@@ -4,15 +4,10 @@ namespace AuditCongress {
 
     class Congresses extends CongressTable {
         
+        use \Util\GetInstance;
+
         private function __construct() {
             parent::__construct("Congresses", "CongressQuery", "CongressRow");
-        }
-
-        private static $congressTable = null;
-        public static function getInstance() {
-            if (self::$congressTable == null) 
-                self::$congressTable = new Congresses();
-            return self::$congressTable;
         }
 
         private static function genericQuery($function, ...$arguments) {

--- a/src/php/audit.congress/objects/congresses/tables/class.session.table.php
+++ b/src/php/audit.congress/objects/congresses/tables/class.session.table.php
@@ -4,15 +4,10 @@ namespace AuditCongress {
 
     class Sessions extends CongressTable {
         
+        use \Util\GetInstance;
+
         private function __construct() {
             parent::__construct("Sessions", "SessionQuery", "SessionRow");
-        }
-
-        private static $sessionTable = null;
-        public static function getInstance() {
-            if (self::$sessionTable == null) 
-                self::$sessionTable = new Sessions();
-            return self::$sessionTable;
         }
 
         private static function genericQuery($function, ...$arguments) {

--- a/src/php/audit.congress/objects/members/tables/class.member.elections.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.elections.php
@@ -3,17 +3,10 @@
 namespace AuditCongress {
 
     class MemberElections extends MemberTable {
-        use GetByBioguideId;
+        use \Util\GetInstance, GetByBioguideId;
 
         private function __construct() {
             parent::__construct("MemberElections", "MemberElectionsQuery", "MemberElectionRow");
-        }
-
-        private static $memberTermsTable = null;
-        public static function getInstance() {
-            if (self::$memberTermsTable == null) 
-                self::$memberTermsTable = new MemberElections();
-            return self::$memberTermsTable;
         }
 
         public static function getByFecId($fecId) {

--- a/src/php/audit.congress/objects/members/tables/class.member.offices.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.offices.php
@@ -3,16 +3,9 @@
 namespace AuditCongress {
 
     class MemberOffices extends MemberTable {
-        use GetByBioguideId, GetById;
+        use \Util\GetInstance, GetByBioguideId, GetById;
         private function __construct() {
             parent::__construct("MemberOffices", "MemberOfficesQuery", "MemberOfficesRow");
-        }
-
-        private static $memberOfficesTable = null;
-        public static function getInstance() {
-            if (self::$memberOfficesTable == null) 
-                self::$memberOfficesTable = new MemberOffices();
-            return self::$memberOfficesTable;
         }
     }
 }

--- a/src/php/audit.congress/objects/members/tables/class.member.socials.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.socials.php
@@ -3,17 +3,10 @@
 namespace AuditCongress {
 
     class MemberSocials extends MemberTable {
-        use GetByBioguideId;
+        use \Util\GetInstance, GetByBioguideId;
 
         private function __construct() {
             parent::__construct("MemberSocials", "MemberSocialsQuery", "MemberSocialsRow");
-        }
-
-        private static $memberSocialsTable = null;
-        public static function getInstance() {
-            if (self::$memberSocialsTable == null) 
-                self::$memberSocialsTable = new MemberSocials();
-            return self::$memberSocialsTable;
         }
     }
 }

--- a/src/php/audit.congress/objects/members/tables/class.member.terms.php
+++ b/src/php/audit.congress/objects/members/tables/class.member.terms.php
@@ -3,17 +3,10 @@
 namespace AuditCongress {
     
     class MemberTerms extends MemberTable {
-        use GetByBioguideId;
+        use \Util\GetInstance, GetByBioguideId;
 
         private function __construct() {
             parent::__construct("MemberTerms", "MemberTermsQuery", "MemberTermRow");
-        }
-
-        private static $memberTermsTable = null;
-        public static function getInstance() {
-            if (self::$memberTermsTable == null) 
-                self::$memberTermsTable = new MemberTerms();
-            return self::$memberTermsTable;
         }
 
         public static function getLastByBioguideId($bioguideId) {

--- a/src/php/audit.congress/objects/members/tables/class.members.php
+++ b/src/php/audit.congress/objects/members/tables/class.members.php
@@ -3,17 +3,10 @@
 namespace AuditCongress {
 
     class Members extends MemberTable {
-        use GetByBioguideId;
+        use \Util\GetInstance, GetByBioguideId;
 
         private function __construct() {
             parent::__construct("Members", "MembersQuery", "MemberRow");
-        }
-
-        private static $membersObject = null;
-        public static function getInstance() {
-            if (self::$membersObject == null) 
-                self::$membersObject = new Members();
-            return self::$membersObject;
         }
 
         //Set the given members image if available (false if not)

--- a/src/php/util/util.general.php
+++ b/src/php/util/util.general.php
@@ -9,6 +9,15 @@ namespace Util {
             return true;
         }
     }
+
+    trait GetInstance {
+        private static $theInstance = null;
+        public static function getInstance() {
+            if (self::$theInstance == null) 
+                self::$theInstance = new static();
+            return self::$theInstance;
+        }
+    }
 }
 
 ?>


### PR DESCRIPTION
Remove getInstance from `\API\RouteGroup`s since it's completely useless there. Add a `getInstance` trait for each table to use instead of duplicating function.

closes #76 