### PR TITLE
Use db config.json for all db connections

### DIFF
--- a/src/py/shared/db.py
+++ b/src/py/shared/db.py
@@ -9,6 +9,8 @@ from shared import util, zjthreads, logger
 
 VALIDATE_DB_API_URL = "http://localhost/audit-congress/api.php?route=validateSchema"
 
+DB_CONFIG = util.readJsonFile("../../../config.json")
+
 TRUNCATE_SQL = "TRUNCATE {}"
 DELETE_SQL = "DELETE FROM {} WHERE {} = {}"
 THREADED_DELETE = False
@@ -22,7 +24,7 @@ LOAD_DATA_INFILE_SQL = "LOAD DATA INFILE '{}' REPLACE INTO TABLE {} FIELDS OPTIO
 
 # Opens a connection with a MySQL host
 def mysql_connect():
-    return mysql.connector.connect(host="127.0.0.1", user="AuditCongress", password="?6n78$y\"\"~'Fvdy", database="auditcongress")
+    return mysql.connector.connect(host=DB_CONFIG["dburl"], user=DB_CONFIG["dbuser"], password=DB_CONFIG["dbpassword"], database=DB_CONFIG["db"])
 
 # Executes a single query string
 def mysql_execute_query(mysql_conn, sql, use_database):

--- a/src/py/shared/util.py
+++ b/src/py/shared/util.py
@@ -23,10 +23,13 @@ def countFiles(inDir):
 
 def ensureFoldersExist(path): os.makedirs(os.path.dirname(path), exist_ok=True)
 
+def readFile(path):
+    with open(path, "r") as file: return file.read()
+def readJsonFile(path): return json.loads(readFile(path))
+
 def saveFileAny(writeType, path, data):
     ensureFoldersExist(path)
     with open(path, writeType) as file: file.write(data)
-    
 def saveBinaryFile(path, data): saveFileAny("wb", path, data)
 def saveFile(path, data): saveFileAny("w", path, data)
 def saveAsCSV(path, data, headers=None):


### PR DESCRIPTION
closes #62 

Remove hardcoded database connections in python scripts. instead, use `config.json` defined in the root folder.