### PR TITLE
Allow optional parameters on api routes

### DIFF
--- a/src/php/api/base.classes/class.route.group.php
+++ b/src/php/api/base.classes/class.route.group.php
@@ -17,8 +17,8 @@ namespace API {
 
         public function name() { return $this->baseRoute; }
 
-        public function addRoute($functionName, $parameters = [], $types = null) {
-            $theRoute = new Route($this->routeBaseClass, $functionName, $parameters, $types);
+        public function addRoute($functionName, $requiredParams = [], $optionalParams = []) {
+            $theRoute = new Route($this->routeBaseClass, $functionName, $requiredParams, $optionalParams);
             $this->addCustomRoute($theRoute);
         }
         public function addCustomRoute($theRoute) {

--- a/src/php/api/routes/actions/class.actions.php
+++ b/src/php/api/routes/actions/class.actions.php
@@ -4,8 +4,8 @@ namespace API {
     class Actions extends RouteGroup {
         public function __construct() {
             parent::__construct("actions", "\AuditCongress\BillActions");
-            $this->addRoute("getById", ["id"]);
-            $this->addRoute("getByBillId", ["billId"]);
+            $this->addRoute("getById", ["id" => "string"]);
+            $this->addRoute("getByBillId", ["billId" => "string"]);
         }
     }
 }


### PR DESCRIPTION
Allow for optional parameters on every api routes along side required ones. These will pass arguements to functions in the order you specify on the array, like so:
`(required_one, required_two, required_three, optional_one, optional_two)`

closes #97 